### PR TITLE
iss215 make OrthogonalLeastSquares.linear_func a static function

### DIFF
--- a/brightwind/analyse/correlation.py
+++ b/brightwind/analyse/correlation.py
@@ -200,6 +200,7 @@ class OrthogonalLeastSquares(CorrelBase):
 
     """
 
+    @staticmethod
     def linear_func(p, x):
         return p[0] * x + p[1]
 


### PR DESCRIPTION
OrthogonalLeastSquares.linear_func has been changed to a static function, consistent with OrdinaryLeastSquares.linear_func.