### PR TITLE
Panda v1+ compatibility upgrdate. Minor test fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Additional labels for pre-release and build metadata are available as extensions
 is not equal to the derived temporal resolution.
 - Added `data_resolution` argument to `average_data_by_period`, `monthly_means`, `coverage` and 
   `merge_datasets_by_period` functions (Issue #[297](https://github.com/brightwind-dev/brightwind/issues/297))
+- Update to work with Pandas 1.3.2. This mostly includes depreciating pd.Timedelta and using pd.DateOffset instead. (Pull request [#312](https://github.com/brightwind-dev/brightwind/pull/312)).
 
 ## [2.0.0]
 - Major changes, notably

--- a/brightwind/analyse/analyse.py
+++ b/brightwind/analyse/analyse.py
@@ -783,7 +783,7 @@ def time_continuity_gaps(data):
     """
     indexes = data.dropna(how='all').index
     resolution = tf._get_data_resolution(indexes)
-    # If the data resolution is `1 month` or `1 year`, then the resolution will 
+    # If the data resolution is `1 month` or `1 year`, then the resolution will be
     # dependent on which month or year. Hence, this rather hacky way to approach it
     resolution_days = (indexes[0] + resolution - indexes[0]) / pd.Timedelta('1 days')
 

--- a/brightwind/analyse/analyse.py
+++ b/brightwind/analyse/analyse.py
@@ -795,7 +795,7 @@ def time_continuity_gaps(data):
     
     if resolution.kwds == {'months': 1}:
         index_filter = ~continuity['Days Lost'].isin([28, 29, 30, 31])
-    elif resolution.kwds == {'years':1}:
+    elif resolution.kwds == {'years': 1}:
         raise NotImplementedError("time_continuity_gaps calculation not implemented yet "
                                   "for timeseries with yearly resolution.")
     else:

--- a/brightwind/analyse/correlation.py
+++ b/brightwind/analyse/correlation.py
@@ -719,8 +719,10 @@ class SimpleSpeedRatio:
         # calculate the coverage of the target data to raise warning if poor
         tar_count = self.data[1].dropna().count()
         tar_res = tf._get_data_resolution(self.data[1].index)
-        max_pts = (self._end_ts - self._start_ts) / tar_res
-        if tar_res == pd.Timedelta(1, unit='M'):  # if is monthly
+        # This is a little hacky but a relatively simple way to convert offsets to timedelta
+        tar_res_as_timeDelta = self._start_ts + tar_res - self._start_ts
+        max_pts = (self._end_ts - self._start_ts) / tar_res_as_timeDelta
+        if tar_res == pd.DateOffset(months=1):  # if is monthly
             # round the result to 0 decimal to make whole months.
             max_pts = np.round(max_pts, 0)
         target_overlap_coverage = tar_count / max_pts

--- a/brightwind/transform/transform.py
+++ b/brightwind/transform/transform.py
@@ -44,10 +44,6 @@ def _freq_str_to_dateoffset(period):
     """
     Convert a pandas frequency string to a pd.DateOffset.
 
-    (Deprecated) Previously the freq str was converted to pd.Timedelta whose support for 'M' (month) and 'Y' (year)
-    has been deprecated in Pandas as they have variable number of days and hence the pd.Timedelta depends on
-    which year or month.
-
     :param period: Frequency string to be converted to a pd.DateOffset
     :type period:  str
     :return:       A pd.DateOffset
@@ -114,14 +110,6 @@ def _get_data_resolution(data_idx):
     most common time frequency. The expected frequency will be one of 'seconds', 'minutes', 'hours', 'days',
     'weeks', 'months', 'years'.
 
-    (Deprecated). Pandas `Timedelta` will no longer be used to support the annual and monthly data resolution as
-    it cannot reliably represent months or years (due to irregular number of days). The underlying functionality
-    has been deprecated from the Pandas library starting in version 1+.
-        This function will return a specific Timedelta if a resolution of month or year is identified due to months and
-        years having irregular numbers of days. These will be:
-        - For monthly data:     pd.Timedelta(1, unit='M')       i.e. 30.436875 days
-        - For annual data:      pd.Timedelta(365, unit='D')     i.e. 365 days
-
     The function also checks the most common time difference against the minimum time difference. If they
     do not match it shows a warning. It is suggested to manually look at the data if such a warning is shown.
 
@@ -145,7 +133,6 @@ def _get_data_resolution(data_idx):
 
         # To check if the resolution is monthly
         resolution == pd.DateOffset(months=1)
-
 
     """
     # ** Strongly suggestion using pandas infer_freq function for this in future revision.

--- a/brightwind/transform/transform.py
+++ b/brightwind/transform/transform.py
@@ -44,6 +44,9 @@ def _freq_str_to_dateoffset(period):
     """
     Convert a pandas frequency string to a pd.DateOffset.
 
+    Pandas frequency strings are available here:
+    https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#dateoffset-objects
+
     :param period: Frequency string to be converted to a pd.DateOffset
     :type period:  str
     :return:       A pd.DateOffset

--- a/brightwind/transform/transform.py
+++ b/brightwind/transform/transform.py
@@ -1,7 +1,6 @@
 import datetime
 import numpy as np
 import pandas as pd
-from pandas.tseries.offsets import DateOffset
 from brightwind.utils import utils
 from brightwind.load.station import _Measurements
 from brightwind.load.station import DATE_INSTEAD_OF_NONE
@@ -45,9 +44,9 @@ def _freq_str_to_dateoffset(period):
     """
     Convert a pandas frequency string to a pd.DateOffset.
 
-    (Deprecated) Previously the freq str was converted to pd.Timedelta whose support
-    for 'M' (month) and 'Y' (year) has been deprecated in Pandas as they have variable
-    number of days and hence the pd.Timedelta depends on which year or month.
+    (Deprecated) Previously the freq str was converted to pd.Timedelta whose support for 'M' (month) and 'Y' (year)
+    has been deprecated in Pandas as they have variable number of days and hence the pd.Timedelta depends on
+    which year or month.
 
     :param period: Frequency string to be converted to a pd.DateOffset
     :type period:  str
@@ -75,8 +74,8 @@ def _freq_str_to_dateoffset(period):
     elif period[-1:] == 'S':
         as_dateoffset = pd.DateOffset(seconds=float(period[:-1]))
     else:
-        raise ValueError('{} period not recognized. Only units "M", "MS", "A", "AS", "W", "D", "H", "T", "min", "S" '
-                         'are recognized')
+        raise ValueError('"{}" period not recognized. Only units "M", "MS", "A", "AS", "W", "D", "H", "T", "min", "S" '
+                         'are recognized'.format(period))
     return as_dateoffset
 
 
@@ -115,13 +114,13 @@ def _get_data_resolution(data_idx):
     most common time frequency. The expected frequency will be one of 'seconds', 'minutes', 'hours', 'days',
     'weeks', 'months', 'years'.
 
-    (Deprecated). Pandas `timedelta` will no longer be used to support the date resolution as it cannot reliably
-    represent months or years (due to irregular number of days). This functionality has been deprecated from the
-    underlying Pandas library starting in version 1+
-    This function will return a specific Timedelta if a resolution of month or year is identified due to months and
-    years having irregular numbers of days. These will be:
-    - For monthly data:     pd.Timedelta(1, unit='M')       i.e. 30.436875 days
-    - For annual data:      pd.Timedelta(365, unit='D')     i.e. 365 days
+    (Deprecated). Pandas `Timedelta` will no longer be used to support the annual and monthly data resolution as
+    it cannot reliably represent months or years (due to irregular number of days). The underlying functionality
+    has been deprecated from the Pandas library starting in version 1+.
+        This function will return a specific Timedelta if a resolution of month or year is identified due to months and
+        years having irregular numbers of days. These will be:
+        - For monthly data:     pd.Timedelta(1, unit='M')       i.e. 30.436875 days
+        - For annual data:      pd.Timedelta(365, unit='D')     i.e. 365 days
 
     The function also checks the most common time difference against the minimum time difference. If they
     do not match it shows a warning. It is suggested to manually look at the data if such a warning is shown.
@@ -139,6 +138,9 @@ def _get_data_resolution(data_idx):
         resolution = bw.transform.transform._get_data_resolution(data.Spd80mS.index)
 
         # To check the number of seconds in resolution
+        print((data.index[0] + resolution - data.index[0]).seconds)
+
+        # To check the unit of resolution
         print(resolution.kwds)
 
         # To check if the resolution is monthly
@@ -268,14 +270,16 @@ def _get_overlapping_data(df1, df2, averaging_prd=None):
     return df1[start:], df2[start:]
 
 
-def _max_coverage_count(data_index, averaged_data_index, data_resolution=None)->pd.Series:
+def _max_coverage_count(data_index, averaged_data_index, data_resolution=None) -> pd.Float64Index:
     """
     For a given resolution of data finds the maximum number of data points in the averaging period
     """
 
-    # If the input is not a pd.DateOffset (which is the valid way of representing time offsets)
-    if not isinstance(data_resolution, pd.DateOffset):
+    if data_resolution is None:
         data_res = _get_data_resolution(data_index)
+    elif not isinstance(data_resolution, pd.DateOffset):
+        raise TypeError('Input data_resolution is {}. A Pandas DateOffset should be used instead.'.format(
+            type(data_resolution).__name__))
     else:
         data_res = data_resolution
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pandas          >= 0.24.0, <=0.25.3
+pandas          >= 0.24.0
 numpy           >= 1.16.4
 scikit-learn    >= 0.19.1
 matplotlib      >= 3.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pandas          >= 0.24.0
+pandas          >= 0.24.0, <=1.3.2
 numpy           >= 1.16.4
 scikit-learn    >= 0.19.1
 matplotlib      >= 3.0.3

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     keywords=['BRIGHT', 'WIND', 'RESOURCE', 'DATA', 'ANALYSTS', 'PROCESSING', 'WASP', 'ROSE', 'WINDFARMER', 'OPENWIND',
               'WIND PRO', 'WINDOGRAPHER'],
     install_requires=[
-        'pandas>=0.24.0, <=0.25.3',
+        'pandas>=0.24.0',
         'numpy>=1.16.4',
         'scikit-learn>=0.19.1',
         'matplotlib>=3.0.3',
@@ -61,6 +61,8 @@ setup(
     classifiers=[
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "License :: OSI Approved :: MIT License",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     keywords=['BRIGHT', 'WIND', 'RESOURCE', 'DATA', 'ANALYSTS', 'PROCESSING', 'WASP', 'ROSE', 'WINDFARMER', 'OPENWIND',
               'WIND PRO', 'WINDOGRAPHER'],
     install_requires=[
-        'pandas>=0.24.0',
+        'pandas>=0.24.0, <=1.3.2',
         'numpy>=1.16.4',
         'scikit-learn>=0.19.1',
         'matplotlib>=3.0.3',

--- a/tests/test_analyse.py
+++ b/tests/test_analyse.py
@@ -21,7 +21,7 @@ def test_monthly_means():
     data_monthly = bw.average_data_by_period(DATA.Spd80mS, period='1M')
     data_monthly = data_monthly[data_monthly.index.month.isin([2, 4, 6, 8])]
     _, monthly_mean_data = bw.monthly_means(data_monthly, return_data=True,
-                                            data_resolution=pd.Timedelta('1M'))
+                                            data_resolution=pd.DateOffset(months=1))
     assert (monthly_mean_data.dropna() == data_monthly).all()
     with pytest.raises(ValueError) as except_info:
         bw.monthly_means(data_monthly, return_data=True)
@@ -59,8 +59,8 @@ def test_time_continuity_gaps():
     # THIS WILL RAISE 3 WARNINGS.
     data_test = DATA.copy()
     data_test.reset_index(inplace=True)
-    data_test['Timestamp'][10] = data_test['Timestamp'][10] + pd.Timedelta('1 min')
-    data_test['Timestamp'][20] = data_test['Timestamp'][20] + pd.Timedelta('9 min')
+    data_test['Timestamp'][10] = data_test['Timestamp'][10] + pd.DateOffset(minutes=1)
+    data_test['Timestamp'][20] = data_test['Timestamp'][20] + pd.DateOffset(minutes=9)
     data_test.set_index('Timestamp', inplace=True)
     gaps_irregular = bw.time_continuity_gaps(data_test)
     assert gaps_irregular.iloc[0, 0] == pd.Timestamp('2016-01-09 18:10:00')
@@ -133,7 +133,7 @@ def test_coverage():
     data1 = data1.drop(drop_indices)
     data1 = data1.set_index('Timestamp')
     assert round(bw.coverage(data1.Spd80mS, period='1M',
-                             data_resolution=pd.Timedelta('10min')).values[0], 8) == 0.00179211
+                             data_resolution=pd.DateOffset(minutes=10)).values[0], 8) == 0.00179211
 
 
 def test_dist_by_dir_sector():

--- a/tests/test_correlation.py
+++ b/tests/test_correlation.py
@@ -237,7 +237,8 @@ def test_synthesize():
     synth = correl.synthesize(target_coverage_threshold=0)
 
     for idx, row in pd.DataFrame(result_ord_lst_sq).iterrows():
-        assert str(row[0]) == str(synth.loc[idx][0])
+        # Comparing the first 6 digits to avoid issuing with floating point precision
+        assert str(row[0])[0:6] == str(synth.loc[idx][0])[0:6]
 
     # Test the synthesise for when the ref_dir is given as input.
     correl = bw.Correl.OrdinaryLeastSquares(MERRA2_NE['WS50m_m/s']['2016-03-02 00:00:00':],

--- a/tests/test_shear.py
+++ b/tests/test_shear.py
@@ -106,7 +106,8 @@ def test_time_series():
 
     # Test attributes
     assert round(shear_by_ts_power_law.alpha.mean(), 4) == 0.1786
-    assert shear_by_ts_log_law.roughness.mean() == 4.306534305567819e+68
+    # Changed to support equality for very large numbers
+    assert (shear_by_ts_log_law.roughness.mean() / 4.306534305567819e+68 - 1) < 1e-6
 
     # Test apply
     shear_by_ts_power_law.apply(DATA['Spd80mN'], 40, 60)

--- a/tests/test_station.py
+++ b/tests/test_station.py
@@ -11,6 +11,7 @@ def _get_schema():
         schema = json.load(json_file)
     return schema
 
+
 SCHEMA = _get_schema()
 
 

--- a/tests/test_station.py
+++ b/tests/test_station.py
@@ -7,7 +7,7 @@ import json
 
 
 def _get_schema():
-    with open(bw.demo_datasets.demo_wra_data_model_schema) as json_file:
+    with open(bw.demo_datasets.iea43_wra_data_model_schema) as json_file:
         schema = json.load(json_file)
     return schema
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -171,7 +171,7 @@ def test_apply_wind_vane_dead_band_offset():
             data['Dir78mS'].fillna(0).round(10)).all()
 
 
-def test_freq_str_to_DateOffset():
+def test_freq_str_to_dateoffset():
     # Excluding monthly periods and above as it will depend on which month or year
     periods = ['1min', '5min', '10min', '15min',
                '1H', '3H', '6H',
@@ -182,10 +182,11 @@ def test_freq_str_to_DateOffset():
                86400.0, 604800.0, 604800.0, 1209600.0]
 
     for idx, period in enumerate(periods):
-        if type(bw.transform.transform._freq_str_to_DateOffset(period)) == pd.DateOffset:
+        if type(bw.transform.transform._freq_str_to_dateoffset(period)) == pd.DateOffset:
             # The data frequency is returned as a DateOffset. The time delta can be in seconds
             # can be derived adding the date offset to an actual date.
-            assert (ref_date + bw.transform.transform._freq_str_to_DateOffset(period) - ref_date).total_seconds() == results[idx]
+            assert (ref_date + bw.transform.transform._freq_str_to_dateoffset(period) - ref_date
+                    ).total_seconds() == results[idx]
 
 
 def test_round_timestamp_down_to_averaging_prd():
@@ -540,8 +541,8 @@ def test_average_data_by_period():
                              52, 72, 129, 111, 157, 150, 20, 24, 118, 178, 160])
     data1 = data1.drop(drop_indices)
     data1 = data1.set_index('Timestamp')
-    assert (bw.average_data_by_period(data1.Spd80mS, period='10min', data_resolution=pd.DateOffset(minutes=10)).dropna() ==
-            data1.Spd80mS).all()
+    assert (bw.average_data_by_period(data1.Spd80mS, period='10min', data_resolution=pd.DateOffset(minutes=10)).dropna()
+            == data1.Spd80mS).all()
     with pytest.raises(ValueError) as except_info:
         bw.average_data_by_period(data1.Spd80mS, period='10min')
     assert str(except_info.value) == "The time period specified is less than the temporal resolution of the data. " \

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -15,6 +15,7 @@ new_offset = 0.236
 wndspd_adj = 8.173555555555556
 wndspd_adj_df = pd.DataFrame([2.0402222222222224, 13.284666666666668, np.NaN, 5.106888888888888, 8.173555555555556])
 wndspd_adj_series = pd.Series([2.0402222222222224, 13.284666666666668, np.NaN, 5.106888888888888, 8.173555555555556])
+ref_date = pd.to_datetime('2000-01-01')
 
 DATA = bw.load_campbell_scientific(bw.demo_datasets.demo_campbell_scientific_data)
 DATA_CLND = bw.apply_cleaning(DATA, bw.demo_datasets.demo_cleaning_file)
@@ -170,19 +171,21 @@ def test_apply_wind_vane_dead_band_offset():
             data['Dir78mS'].fillna(0).round(10)).all()
 
 
-def test_freq_str_to_timedelta():
+def test_freq_str_to_DateOffset():
+    # Excluding monthly periods and above as it will depend on which month or year
     periods = ['1min', '5min', '10min', '15min',
                '1H', '3H', '6H',
-               '1D', '7D', '1W', '2W',
-               '1MS', '1M', '3M', '6MS',
-               '1AS', '1A', '3A']
+               '1D', '7D', '1W', '2W'
+               ]
     results = [60.0, 300.0, 600.0, 900.0,
                3600.0, 10800.0, 21600.0,
-               86400.0, 604800.0, 604800.0, 1209600.0,
-               2629746.0, 2629746.0, 7889238.0, 15778476.0,
-               31536000.0, 31536000.0, 94608000.0]
+               86400.0, 604800.0, 604800.0, 1209600.0]
+
     for idx, period in enumerate(periods):
-        assert bw.transform.transform._freq_str_to_timedelta(period).total_seconds() == results[idx]
+        if type(bw.transform.transform._freq_str_to_DateOffset(period)) == pd.DateOffset:
+            # The data frequency is returned as a DateOffset. The time delta can be in seconds
+            # can be derived adding the date offset to an actual date.
+            assert (ref_date + bw.transform.transform._freq_str_to_DateOffset(period) - ref_date).total_seconds() == results[idx]
 
 
 def test_round_timestamp_down_to_averaging_prd():
@@ -197,24 +200,25 @@ def test_round_timestamp_down_to_averaging_prd():
 
 
 def test_get_data_resolution():
+    # Dateoffset is used to represent data resolution
     import warnings
     series1 = DATA['Spd80mS'].index
-    assert bw.transform.transform._get_data_resolution(series1).seconds == 600
+    assert bw.transform.transform._get_data_resolution(series1).kwds == {'minutes': 10}
 
     series2 = pd.date_range('2010-01-01', periods=150, freq='H')
-    assert bw.transform.transform._get_data_resolution(series2).seconds == 3600
+    assert bw.transform.transform._get_data_resolution(series2).kwds == {'hours': 1}
 
     series1 = bw.average_data_by_period(DATA['Spd80mN'], period='1M', coverage_threshold=0, return_coverage=False)
-    assert bw.transform.transform._get_data_resolution(series1.index) == pd.Timedelta(1, unit='M')
+    assert bw.transform.transform._get_data_resolution(series1.index).kwds == {'months': 1}
 
     series1 = bw.average_data_by_period(DATA['Spd80mN'], period='1AS', coverage_threshold=0, return_coverage=False)
-    assert bw.transform.transform._get_data_resolution(series1.index) == pd.Timedelta(365, unit='D')
+    assert bw.transform.transform._get_data_resolution(series1.index).kwds == {'years': 1}
 
     # hourly series with one instance where difference between adjacent timestamps is 10 min
     series3 = pd.date_range('2010-04-15', '2010-05-01', freq='H').union(pd.date_range('2010-05-01 00:10:00', periods=20,
                                                                                       freq='H'))
     with warnings.catch_warnings(record=True) as w:
-        assert bw.transform.transform._get_data_resolution(series3).seconds == 3600
+        assert bw.transform.transform._get_data_resolution(series3).kwds == {'hours': 1}
         assert len(w) == 1
 
 
@@ -510,7 +514,7 @@ def test_average_data_by_period():
     data_test.sort_index(inplace=True)
     data_monthly, coverage_monthly = bw.average_data_by_period(data_test, period='1M', wdir_column_names='Dir78mS',
                                                                return_coverage=True,
-                                                               data_resolution=pd.Timedelta('10 min'))
+                                                               data_resolution=pd.DateOffset(minutes=10))
     table_count = data_test.resample('1MS', axis=0, closed='left', label='left', base=0,
                                      convention='start', kind='timestamp').count()
     assert (table_count['Dir78mS']['2016-01-01'] / (31 * 24 * 6) - coverage_monthly['Dir78mS_Coverage']['2016-01-01']
@@ -536,7 +540,7 @@ def test_average_data_by_period():
                              52, 72, 129, 111, 157, 150, 20, 24, 118, 178, 160])
     data1 = data1.drop(drop_indices)
     data1 = data1.set_index('Timestamp')
-    assert (bw.average_data_by_period(data1.Spd80mS, period='10min', data_resolution=pd.Timedelta('10 min')).dropna() ==
+    assert (bw.average_data_by_period(data1.Spd80mS, period='10min', data_resolution=pd.DateOffset(minutes=10)).dropna() ==
             data1.Spd80mS).all()
     with pytest.raises(ValueError) as except_info:
         bw.average_data_by_period(data1.Spd80mS, period='10min')
@@ -634,8 +638,8 @@ def test_merge_datasets_by_period():
                                             wdir_column_names_1='WD50m_deg', wdir_column_names_2='Dir78mS',
                                             coverage_threshold_1=0, coverage_threshold_2=0,
                                             aggregation_method_1='mean', aggregation_method_2='mean',
-                                            data_1_resolution=pd.Timedelta('1H'),
-                                            data_2_resolution=pd.Timedelta('10min'))
+                                            data_1_resolution=pd.DateOffset(hours=1),
+                                            data_2_resolution=pd.DateOffset(minutes=10))
 
     assert round(mrgd_data['Spd80mN_Coverage'].values[0], 8) == 0.00179211
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -189,8 +189,8 @@ def test_freq_str_to_dateoffset():
             assert (ref_date + bw.transform.transform._freq_str_to_dateoffset(period) - ref_date
                     ).total_seconds() == results[idx]
 
-    # Check that data frequency is returned as a DateOffset.
-    assert type(bw.transform.transform._freq_str_to_dateoffset(period)) == pd.DateOffset
+        # Check that data frequency is returned as a DateOffset.
+        assert type(bw.transform.transform._freq_str_to_dateoffset(period)) == pd.DateOffset
 
 
 def test_round_timestamp_down_to_averaging_prd():


### PR DESCRIPTION
Modifications to allow Brightwind library to be compatible with latest Pandas version (1+). The changes should allow the library to remain backward compatible with Pandas v0.24 as well.

Changes include:
- Panda v1+ has dropped support for 'M' and 'Y' in timeDelta function as the answer would vary depending on month and year. Instead this branch uses DateOffset to represent data frequency.
- All tests related to this change pass. There are some existing test conflict in the current dev branch unrelated to the new changes
- Some minor test conflicts are arising out of numerical floating point precision issues and there are minor fixes in the branch for those.

Suggestions:
- In future revision we should consider using pandas `infer_freq` to estimate data resolution. The current version is unable to determine frequency accurately for special cases such as bimonthly or quarterly.