### PR TITLE
Iss #224 plot scatter duplicate name

### DIFF
--- a/brightwind/analyse/plot.py
+++ b/brightwind/analyse/plot.py
@@ -461,8 +461,8 @@ def plot_scatter(x, y, trendline_y=None, trendline_x=None, line_of_slope_1=False
 
     # if x and y names are the same then rename pd.Series names to be unique
     if x.name == y.name:
-        x = x.rename(x.name + '_0')
-        y = y.rename(y.name + '_1')
+        x = x.rename(x.name + '_x')
+        y = y.rename(y.name + '_y')
 
     if x_label is None:
         x_label = x.name

--- a/brightwind/analyse/plot.py
+++ b/brightwind/analyse/plot.py
@@ -459,6 +459,11 @@ def plot_scatter(x, y, trendline_y=None, trendline_x=None, line_of_slope_1=False
     elif type(y) is np.ndarray or type(y) is list:
         y = pd.Series(y).rename('y')
 
+    # if x and y names are the same then rename pd.Series names to be unique
+    if x.name == y.name:
+        x = x.rename(x.name + '_0')
+        y = y.rename(y.name + '_1')
+
     if x_label is None:
         x_label = x.name
     if y_label is None:

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -30,6 +30,7 @@ def test_plot_scatter():
                          x_limits=(50, 300), y_limits=(250, 300))
     bw.plot_scatter_wspd(DATA.Spd80mN, DATA.Spd80mS, x_label='Speed at 80m North',
                          y_label='Speed at 80m South', x_limits=(0, 25), y_limits=(0, 25))
+    bw.plot_scatter_wspd(DATA.Spd80mN, DATA.Spd80mN, x_limits=(0, 25), y_limits=(0, 25))
 
     assert True
 


### PR DESCRIPTION
issue #224

fixed bug, now if x and y pandas series have same name then the correct scatter plot is generated