### PR TITLE
[basic_stats] iss #307 fixed bug due to pandas version and python 3.8

### DIFF
--- a/brightwind/analyse/analyse.py
+++ b/brightwind/analyse/analyse.py
@@ -907,9 +907,9 @@ def basic_stats(data):
 
     """
     if isinstance(data, pd.DataFrame):
-        return data.describe(percentiles=[0.5]).T.drop(['50%'], axis=1)
+        return data.describe(percentiles=[0.5], include='all').T.drop(['50%'], axis=1)
     else:
-        return data.to_frame().describe(percentiles=[0.5]).T.drop(['50%'], axis=1)
+        return data.to_frame().describe(percentiles=[0.5], include='all').T.drop(['50%'], axis=1)
 
 
 def dist_12x24(var_series, aggregation_method='mean', var_name_label=None, return_data=False):


### PR DESCRIPTION
I think that python version used when having this error was Python 3.8.x, as I was able to replicate this issue ONLY when using Python 3.8.13. This error was raised with any `numpy version > 1.18.1` and `pandas==0.25.3`. This is probably due to a bug in ...\Anaconda3\envs\Python38\lib\site-packages\pandas\core\generic.py -> `describe` function

the `describe` function is taking as default input `include=None` but then np.numeric doesn't work. As for description below, for our application of describe function there is no need to give as input `include=None` but `include="All"` is ok and is not generating this error.

![image](https://user-images.githubusercontent.com/65398058/163246437-b48f7f9b-3464-46dc-9351-b1facd0e6de9.png)
