### PR TITLE
Iss315 matplotlib version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ is not equal to the derived temporal resolution.
 6. Allow `dist()` function to take a pd.DataFrame so user can plot multiple distributions on the same plot. (Issue #[264](https://github.com/brightwind-dev/brightwind/issues/264))
    1. As part of this added subplotting functionality for bar plots
 7. Added subplotting functionality to `sector_ratio` and improved user control of plotting (Issue #[309](https://github.com/brightwind-dev/brightwind/issues/309)).
+8. Update to work with matplotlib 3.5.2 and bug fix for plot_freq_distribution and dist functions (Issue #[315](https://github.com/brightwind-dev/brightwind/issues/315)). 
 
 
 ## [2.0.0]

--- a/brightwind/analyse/analyse.py
+++ b/brightwind/analyse/analyse.py
@@ -433,7 +433,7 @@ def dist(var_to_bin, var_to_bin_against=None, bins=None, bin_labels=None, x_labe
     if not isinstance(aggregation_method, str):
         aggregation_method = aggregation_method.__name__
 
-    graph = plt.plot_freq_distribution(distributions.replace([np.inf, -np.inf], np.NAN).dropna(),
+    graph = plt.plot_freq_distribution(distributions.replace([np.inf, -np.inf], np.NAN),
                                        max_y_value=max_y_value,
                                        x_tick_labels=bin_labels, x_label=x_label, y_label=aggregation_method,
                                        legend=legend)

--- a/brightwind/analyse/plot.py
+++ b/brightwind/analyse/plot.py
@@ -1090,7 +1090,7 @@ def plot_freq_distribution(data, max_y_value=None, x_tick_labels=None, x_label=N
 
     fig = plt.figure(figsize=(15, 8))
     ax = fig.add_axes([0.1, 0.1, 0.8, 0.8])
-    _bar_subplot(data.replace([np.inf, -np.inf], np.NAN).dropna(), x_label=x_label,
+    _bar_subplot(data.replace([np.inf, -np.inf], np.NAN), x_label=x_label,
                  y_label=y_label, max_bar_axis_limit=max_y_value,
                  bin_tick_labels=x_tick_labels, bar_tick_label_format=bar_tick_label_format,
                  legend=legend, total_width=total_width, ax=ax)

--- a/brightwind/analyse/plot.py
+++ b/brightwind/analyse/plot.py
@@ -913,6 +913,11 @@ def _bar_subplot(data, x_label=None, y_label=None, min_bar_axis_limit=None, max_
     if (line_width < 0) or (line_width > 5):
         raise ValueError('The line_width value should be between 0 and 5.')
 
+    if (bin_tick_labels is not None) and (bin_tick_labels != []):
+        if len(bin_tick_labels) != len(data.index):
+            raise ValueError('The length of the input bin_tick_labels list is different than the number '
+                             'of entries in the data index.')
+
     if min_bar_axis_limit is None:
         min_bar_axis_limit = 0
     if max_bar_axis_limit is None:


### PR DESCRIPTION
Tests were performed from matplotlib==3.1.3 up to matplotlib==3.5.2 and confirmed that bug for ti_by_speed due to matplotlib version is fixed.