### PR TITLE
Iss344 numpy version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ is not equal to the derived temporal resolution.
    1. As part of this added subplotting functionality for bar plots
 7. Added subplotting functionality to `sector_ratio` and improved user control of plotting (Issue #[309](https://github.com/brightwind-dev/brightwind/issues/309)).
 8. Update to work with matplotlib 3.5.2 and bug fix for plot_freq_distribution and dist functions (Issue #[315](https://github.com/brightwind-dev/brightwind/issues/315)). 
+9. Update to work with numpy>=1.20.0 when pandas=0.25.3. (Issue #[344](https://github.com/brightwind-dev/brightwind/issues/344)). 
 
 
 ## [2.0.0]

--- a/brightwind/analyse/plot.py
+++ b/brightwind/analyse/plot.py
@@ -173,18 +173,18 @@ def plot_timeseries(data, date_from='', date_to='', y_limits=(None, None)):
     """
     Plot a timeseries of data.
 
-    :param data: Data in the form of a Pandas DataFrame/Series to plot.
-    :type data: pd.DataFrame, pd.Series
-    :param date_from: Start date used for plotting, if not specified the first timestamp of data is considered. Should
-        be in yyyy-mm-dd format
-    :type date_from: str
-    :param date_to: End date used for plotting, if not specified last timestamp of data is considered. Should
-        be in yyyy-mm-dd format
-    :type date_to: str
-    :param y_limits: y-axis min and max limits. Default is (None, None).
-    :type y_limits: tuple, None
-    :return: Timeseries plot
-    :rtype: matplotlib.figure.Figure
+    :param data:        Data in the form of a Pandas DataFrame/Series to plot.
+    :type data:         pd.DataFrame, pd.Series
+    :param date_from:   Start date used for plotting, if not specified the first timestamp of data is considered. Should
+                        be in yyyy-mm-dd format
+    :type date_from:    str
+    :param date_to:     End date used for plotting, if not specified last timestamp of data is considered. Should
+                        be in yyyy-mm-dd format
+    :type date_to:      str
+    :param y_limits:    y-axis min and max limits. Default is (None, None).
+    :type y_limits:     tuple, None
+    :return:            Timeseries plot
+    :rtype:             matplotlib.figure.Figure
 
     **Example usage**
     ::

--- a/brightwind/analyse/shear.py
+++ b/brightwind/analyse/shear.py
@@ -1068,7 +1068,7 @@ class Shear:
         idx = pd.date_range('2017-01-01 00:00', '2017-01-01 23:00', freq='1H')
 
         # create new dataframe with 24 rows only interval number of unique values
-        df = pd.DataFrame(index=pd.DatetimeIndex(idx).time, columns=df_copy.columns)
+        df = pd.DataFrame({cols: [np.NaN] for cols in df_copy.columns}, index=pd.DatetimeIndex(idx).time)
         df = pd.concat(
             [(df[df_copy.index[0].hour:]), (df[:df_copy.index[0].hour])],
             axis=0)

--- a/brightwind/transform/transform.py
+++ b/brightwind/transform/transform.py
@@ -251,12 +251,18 @@ def _get_overlapping_data(df1, df2, averaging_prd=None):
     # If the start timestamp just happens to be missing from the data, add in a NaN so the
     # averaging will start from this timestamp.
     if not (df2.index == start).any():
-        df2.loc[pd.to_datetime(start)] = np.NaN
+        if type(df2) == pd.DataFrame:
+            df2 = df2.append(pd.DataFrame({cols: [np.NaN] for cols in df2.columns}, index=[pd.to_datetime(start)]))
+        else:
+            df2[pd.to_datetime(start)] = np.NaN
         df2.sort_index(inplace=True)
     if not (df1.index == start).any():
-        df1.loc[pd.to_datetime(start)] = np.NaN
+        # df1.loc[pd.to_datetime(start)] = np.NaN
+        if type(df1) == pd.DataFrame:
+            df1 = df1.append(pd.DataFrame({cols: [np.NaN] for cols in df1.columns}, index=[pd.to_datetime(start)]))
+        else:
+            df1[pd.to_datetime(start)] = np.NaN
         df1.sort_index(inplace=True)
-
     return df1[start:], df2[start:]
 
 


### PR DESCRIPTION
I did tests for different versions of numpy >= 1.20 and pandas >= 0.25.0 and errors below for #344 are solved. 
FAILED tests/test_correlation.py::test_synthesize - TypeError: Cannot interpret '<attribute 'dtype' of 'numpy.generic' objects>' as a data type
FAILED tests/test_correlation.py::test_speed_sort - TypeError: Cannot interpret '<attribute 'dtype' of 'numpy.generic' objects>' as a data type
FAILED tests/test_shear.py::test_time_of_day - AttributeError: type object 'object' has no attribute 'dtype'
FAILED tests/test_transform.py::test_merge_datasets_by_period - TypeError: Cannot interpret '<attribute 'dtype' of 'numpy.generic' objects>' as a data type