### PR TITLE
[Iss359] Fix calculation of mean speed from frequency table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,8 @@ to true. (Issue # [334](https://github.com/brightwind-dev/brightwind/issues/334)
 10. Updated `plot_timeseries` to use a subplot function (`_timeseries_subplot`) and added arguments _x_label_, _y_label_, _x_tick_label_angle_, 
 _line_colors_, _legend_ and _figure_size_. (Issue #[349](https://github.com/brightwind-dev/brightwind/issues/349)).
 11. Address errors and warnings generated for `Shear.TimeOfDay` and `Shear` when pandas >=1.0.0 (Issue #[347](https://github.com/brightwind-dev/brightwind/issues/347)).
-12. In `average_data_by_period()` fixed issue when wind direction average is derived for a period equal to the data resolution period 
-(Issue #[319](https://github.com/brightwind-dev/brightwind/issues/319)).
-13. In `_calc_mean_speed_of_freq_tab` for `export_tab_file` fix issue around using wind speed bins less than 1 m/s.
+12. In `average_data_by_period()` fixed issue when wind direction average is derived for a period equal to the data resolution period (Issue #[319](https://github.com/brightwind-dev/brightwind/issues/319)).
+13. In `_calc_mean_speed_of_freq_tab` for `export_tab_file` fix issue around using wind speed bins less than 1 m/s (Issue #[359](https://github.com/brightwind-dev/brightwind/issues/359)).
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ _line_colors_, _legend_ and _figure_size_. (Issue #[349](https://github.com/brig
 11. Address errors and warnings generated for `Shear.TimeOfDay` and `Shear` when pandas >=1.0.0 (Issue #[347](https://github.com/brightwind-dev/brightwind/issues/347)).
 12. In `average_data_by_period()` fixed issue when wind direction average is derived for a period equal to the data resolution period 
 (Issue #[319](https://github.com/brightwind-dev/brightwind/issues/319)).
+13. In `_calc_mean_speed_of_freq_tab` for `export_tab_file` fix issue around using wind speed bins less than 1 m/s.
 
 
 

--- a/brightwind/export/export.py
+++ b/brightwind/export/export.py
@@ -15,7 +15,7 @@ def _calc_mean_speed_of_freq_tab(freq_tab):
     :return:
     """
     local_freq_tab = freq_tab.copy()
-    local_freq_tab.index = {(interval.right + interval.left)/2 for interval in local_freq_tab.index}
+    local_freq_tab.index = [(interval.right + interval.left)/2 for interval in local_freq_tab.index]
     sum_winds_for_all_sectors = local_freq_tab.sum(axis=1, skipna=True)
     mid_bin_wind_speed = local_freq_tab.index.to_series()
     mean_wind_speed = (sum(sum_winds_for_all_sectors * mid_bin_wind_speed)) / sum(sum_winds_for_all_sectors)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,6 +1,7 @@
 import pytest
 import brightwind as bw
 import os
+import numpy as np
 
 DATA = bw.load_csv(bw.demo_datasets.demo_data)
 DATA = bw.apply_cleaning(DATA, bw.demo_datasets.demo_cleaning_file)
@@ -24,3 +25,9 @@ def test_export_to_csv():
 
     bw.export_csv(DATA, file_name='export_to_csv_tab.tab', folder_path=TEMP_FOLDER, sep='\t')
     assert True
+
+def test_calc_mean_speed_of_freq_tab():
+    fig, freq_tab = bw.freq_table(DATA.Spd80mN, DATA.Dir38mS, return_data=True)
+    assert round(bw.export.export._calc_mean_speed_of_freq_tab(freq_tab), 5) == 7.51925
+    fig, freq_tab = bw.freq_table(DATA.Spd80mN, DATA.Dir38mS, var_bin_array=np.arange(0, 41, 0.5), return_data=True)
+    assert round(bw.export.export._calc_mean_speed_of_freq_tab(freq_tab), 5) == 7.5206

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -26,8 +26,10 @@ def test_export_to_csv():
     bw.export_csv(DATA, file_name='export_to_csv_tab.tab', folder_path=TEMP_FOLDER, sep='\t')
     assert True
 
+
 def test_calc_mean_speed_of_freq_tab():
     fig, freq_tab = bw.freq_table(DATA.Spd80mN, DATA.Dir38mS, return_data=True)
     assert round(bw.export.export._calc_mean_speed_of_freq_tab(freq_tab), 5) == 7.51925
-    fig, freq_tab = bw.freq_table(DATA.Spd80mN, DATA.Dir38mS, var_bin_array=np.arange(0, 41, 0.5), return_data=True)
+    fig, freq_tab = bw.freq_table(DATA.Spd80mN, DATA.Dir38mS, var_bin_array=list(np.arange(0, 41, 0.5)),
+                                  return_data=True)
     assert round(bw.export.export._calc_mean_speed_of_freq_tab(freq_tab), 5) == 7.5206


### PR DESCRIPTION
Fix bug in `_calc_mean_speed_of_tab` which arises when the wind speed bin is less than 1 m/s. The bug involved undesired reordering of the frequency table index.