### PR TITLE
[Iss269] freq_table option to give input target speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ _line_colors_, _legend_ and _figure_size_. (Issue #[349](https://github.com/brig
 11. Address errors and warnings generated for `Shear.TimeOfDay` and `Shear` when pandas >=1.0.0 (Issue #[347](https://github.com/brightwind-dev/brightwind/issues/347)).
 12. In `average_data_by_period()` fixed issue when wind direction average is derived for a period equal to the data resolution period 
 (Issue #[319](https://github.com/brightwind-dev/brightwind/issues/319)).
+13. In `freq_tab()` added option to give as input target wind speed we want the mean frequency distribution to have 
+(Issue #[269](https://github.com/brightwind-dev/brightwind/issues/269)).
 
 
 

--- a/brightwind/analyse/analyse.py
+++ b/brightwind/analyse/analyse.py
@@ -872,8 +872,8 @@ def dist_matrix_by_dir_sector(var_series, var_to_bin_by_series, direction_series
 
 def freq_table(var_series, direction_series, var_bin_array=np.arange(-0.5, 41, 1), var_bin_labels=None, sectors=12,
                direction_bin_array=None, direction_bin_labels=None, freq_as_percentage=True, seasonal_adjustment=False,
-               coverage_threshold=0.8, var_series_mean_target=None,
-               plot_bins=None, plot_labels=None, return_data=False):
+               coverage_threshold=0.8, var_series_mean_target=None, plot_bins=None, plot_labels=None,
+               return_data=False):
     """
     Create a frequency distribution table, typically of wind speed and wind direction i.e. how often the wind
     blows within a certain wind speed bin and wind direction. This will plot a wind rose by default or if
@@ -895,52 +895,59 @@ def freq_table(var_series, direction_series, var_bin_array=np.arange(-0.5, 41, 1
            of the dataset. This to take into account leap years.
         5) Finally, sum each weighted averaged monthly frequency distribution to get a total distribution
 
-    :param var_series:          Series of variable to be binned
-    :type var_series:           pandas.Series
-    :param direction_series:    Series of wind directions between [0-360]
-    :type direction_series:     pandas.Series
-    :param var_bin_array:       List of numbers where adjacent elements of array form a bin. For instance, for bins
-                                [0,3),[3,8),[8,10) the list will be [0, 3, 8, 10]. By default it is [-0.5, 0.5),
-                                [0.5, 1.5], ...., [39.5, 40.5)
-    :type var_bin_array:        list
-    :param var_bin_labels:      Optional, an array of labels to use for variable bins
-    :type var_bin_labels:       list
-    :param sectors:             Number of sectors to bin direction to. The first sector is centered at 0 by default.
-                                To change that behaviour specify direction_bin_array, it overwrites sectors
-    :type sectors:              int
-    :param direction_bin_array: To add custom bins for direction sectors, overwrites sectors. For instance,
-                                for direction bins [0,120), [120, 215), [215, 360) the list would be [0, 120, 215, 360]
-    :type direction_bin_array:  list
-    :param direction_bin_labels: Optional, you can specify an array of labels to be used for the bins. uses string
-                                labels of the format '30-90' by default
-    :type direction_bin_labels: list(float), list(str)
-    :param freq_as_percentage:  Optional, True by default. Returns the frequency as percentages. To return just the
-                                count, set to False
-    :type freq_as_percentage:   bool
-    :param seasonal_adjustment: Optional, False by default. If True, returns the frequency distribution seasonal
-                                adjusted
-    :type seasonal_adjustment:  bool
-    :param coverage_threshold:  In this case monthly coverage threshold. Only applied if `seasonal_adjustment` is True.
-                                Coverage is defined as the ratio of the number of data points present in the month and
-                                the maximum number of data points that a month should have. Example, for 10 minute data
-                                for June, the maximum number of data points is 43,200. But if the number if data points
-                                available is only 30,000 the coverage is 0.69. A coverage_threshold value of 0.8 will
-                                filter out any months with a coverage less than this. Coverage_threshold should be a
-                                value between 0 and 1. If it is None or 0, data is not filtered. Default value is 0.8.
-    :type coverage_threshold:   int, float or None
-    :param plot_bins:           Bins to use for gradient in the rose. Different bins will be plotted with different
-                                color. Chooses six bins to plot by default '0-3 m/s', '4-6 m/s', '7-9 m/s', '10-12 m/s',
-                                '13-15 m/s' and '15+ m/s'. If you change var_bin_array this should be changed in
-                                accordance with it.
-    :type plot_bins:            list
-    :param plot_labels:         (Optional) Labels to use for different colors in the rose. By default chooses
-                                the end points of bin
-    :type plot_labels:          list(str), list(float)
-    :param return_data:         Set to True if you want to return the frequency table too.
-    :type return_data:          bool
-    :returns:                   A wind rose plot with gradients in the rose. Also returns a frequency table if
-                                return_data is True
-    :rtype:                     plot or tuple(plot, pandas.DataFrame)
+    :param var_series:              Series of variable to be binned
+    :type var_series:               pandas.Series
+    :param direction_series:        Series of wind directions between [0-360]
+    :type direction_series:         pandas.Series
+    :param var_bin_array:           List of numbers where adjacent elements of array form a bin. For instance, for bins
+                                    [0,3),[3,8),[8,10) the list will be [0, 3, 8, 10]. By default it is [-0.5, 0.5),
+                                    [0.5, 1.5], ...., [39.5, 40.5)
+    :type var_bin_array:            list
+    :param var_bin_labels:          Optional, an array of labels to use for variable bins
+    :type var_bin_labels:           list
+    :param sectors:                 Number of sectors to bin direction to. The first sector is centered at 0 by default.
+                                    To change that behaviour specify direction_bin_array, it overwrites sectors
+    :type sectors:                  int
+    :param direction_bin_array:     To add custom bins for direction sectors, overwrites sectors. For instance,
+                                    for direction bins [0,120), [120, 215), [215, 360) the list would be
+                                    [0, 120, 215, 360]
+    :type direction_bin_array:      list
+    :param direction_bin_labels:    Optional, you can specify an array of labels to be used for the bins. uses string
+                                    labels of the format '30-90' by default
+    :type direction_bin_labels:     list(float), list(str)
+    :param freq_as_percentage:      Optional, True by default. Returns the frequency as percentages. To return just the
+                                    count, set to False
+    :type freq_as_percentage:       bool
+    :param seasonal_adjustment:     Optional, False by default. If True, returns the frequency distribution seasonal
+                                    adjusted
+    :type seasonal_adjustment:      bool
+    :param coverage_threshold:      In this case monthly coverage threshold. Only applied if `seasonal_adjustment`
+                                    is True. Coverage is defined as the ratio of the number of data points present in
+                                    the month and the maximum number of data points that a month should have.
+                                    Example, for 10 minute data for June, the maximum number of data points is 43,200.
+                                    But if the number if data points available is only 30,000 the coverage is 0.69.
+                                    A coverage_threshold value of 0.8 will filter out any months with a coverage less
+                                    than this. Coverage_threshold should be a value between 0 and 1.
+                                    If it is None or 0, data is not filtered. Default value is 0.8.
+    :type coverage_threshold:       int, float or None
+    :param var_series_mean_target:  Target value used to scale the mean of the frequency distribution.
+                                    If None then the mean of the frequency distribution is set to match the mean of
+                                    the input var_series. The mean of frequency distribution will differ respect the
+                                    target value by max 0.01%.
+    :type var_series_mean_target:   int, float or None
+    :param plot_bins:               Bins to use for gradient in the rose. Different bins will be plotted with different
+                                    color. Chooses six bins to plot by default '0-3 m/s', '4-6 m/s', '7-9 m/s',
+                                    '10-12 m/s', '13-15 m/s' and '15+ m/s'. If you change var_bin_array this should be
+                                    changed in accordance with it.
+    :type plot_bins:                list
+    :param plot_labels:             (Optional) Labels to use for different colors in the rose. By default chooses
+                                    the end points of bin
+    :type plot_labels:              list(str), list(float)
+    :param return_data:             Set to True if you want to return the frequency table too.
+    :type return_data:              bool
+    :returns:                       A wind rose plot with gradients in the rose. Also returns a frequency table if
+                                    return_data is True
+    :rtype:                         plot or tuple(plot, pandas.DataFrame)
 
     **Example usage**
     ::
@@ -979,6 +986,13 @@ def freq_table(var_series, direction_series, var_bin_array=np.arange(-0.5, 41, 1
         rose, tab = bw.freq_table(data.Spd40mN, data.Dir38mS, direction_bin_array=[0,90,130,200,360],
                                   direction_bin_labels=['northerly','easterly','southerly','westerly'],
                                   plot_bins=[0,8,14,41], plot_labels=None, return_data=True)
+        display(rose)
+        display(freq_table)
+
+        # Custom direction and set target mean frequency distribution
+        rose, tab = bw.freq_table(data.Spd40mN, data.Dir38mS, direction_bin_array=[0,90,130,200,360],
+                                  direction_bin_labels=['northerly','easterly','southerly','westerly'],
+                                  var_series_mean_target=8, plot_bins=[0,8,14,41], plot_labels=None, return_data=True)
         display(rose)
         display(freq_table)
     """

--- a/brightwind/export/export.py
+++ b/brightwind/export/export.py
@@ -15,7 +15,7 @@ def _calc_mean_speed_of_freq_tab(freq_tab):
     :return:
     """
     local_freq_tab = freq_tab.copy()
-    local_freq_tab.index = {(interval.right + interval.left)/2 for interval in local_freq_tab.index}
+    local_freq_tab.index = [(interval.right + interval.left)/2 for interval in local_freq_tab.index]
     sum_winds_for_all_sectors = local_freq_tab.sum(axis=1, skipna=True)
     mid_bin_wind_speed = local_freq_tab.index.to_series()
     mean_wind_speed = (sum(sum_winds_for_all_sectors * mid_bin_wind_speed)) / sum(sum_winds_for_all_sectors)

--- a/tests/test_analyse.py
+++ b/tests/test_analyse.py
@@ -189,6 +189,7 @@ def test_freq_table():
                                direction_bin_labels=['lowest', 'lower', 'mid', 'high'], return_data=True)
     assert (tab.columns == ['lowest', 'lower', 'mid', 'high']).all()
     assert tab.sum().round(6).to_dict() == {'lowest': 14.800378, 'lower': 9.95062, 'mid': 25.807943, 'high': 49.441059}
+    assert round(DATA.Spd40mN.mean(), 2) == round(bw.export.export._calc_mean_speed_of_freq_tab(tab), 2)
 
     assert bw.freq_table(DATA.Spd40mN, DATA.Dir38mS, plot_bins=[0, 3, 6, 9, 12, 15, 41],
                          plot_labels=['0-3 m/s', '4-6 m/s', '7-9 m/s', '10-12 m/s', '13-15 m/s', '15+ m/s'],
@@ -206,12 +207,12 @@ def test_freq_table():
                                                                            'southerly': 22.990124,
                                                                            'westerly': 55.670309}
 
-    assert bw.freq_table(DATA.T2m, DATA.Dir78mS, var_bin_array=[-10, 0, 10, 20], var_bin_labels=['low', 'mid', 'high'],
-                         plot_bins=[-10, 0, 10, 20], plot_labels=None,
-                         return_data=True)[1].sum().round(6)[8:].to_dict() == {'225.0-255.0': 12.166183,
-                                                                               '255.0-285.0': 14.08716,
-                                                                               '285.0-315.0': 10.746167,
-                                                                               '315.0-345.0': 3.076073}
+    assert bw.freq_table(DATA.T2m, DATA.Dir78mS, var_bin_array=[-10, 0, 10, 30], var_bin_labels=['low', 'mid', 'high'],
+                         plot_bins=[-10, 0, 10, 30], plot_labels=None,
+                         return_data=True)[1].sum().round(6)[8:].to_dict() == {'225.0-255.0': 12.135989,
+                                                                               '255.0-285.0': 14.009204,
+                                                                               '285.0-315.0': 10.681815,
+                                                                               '315.0-345.0': 3.065488}
 
     # Apply seasonal adjustment and impose coverage threshold to 70%
     plot_wind_rose, freq_tbl_seas_adj = bw.freq_table(DATA.Spd40mN, DATA.Dir38mS, seasonal_adjustment=True,
@@ -241,7 +242,7 @@ def test_freq_table():
 
     fig_rose = bw.freq_table(DATA.Spd40mN['2016-06-01':'2017-09-30'], DATA.Dir38mS['2016-06-01':'2017-09-30'],
                              return_data=False, seasonal_adjustment=True, coverage_threshold=0.9)
-    assert 'Text' not in str(fig_rose.get_default_bbox_extra_artists())
+    assert 'Text' in str(fig_rose.get_default_bbox_extra_artists())
 
 
 def test_dist():

--- a/tests/test_analyse.py
+++ b/tests/test_analyse.py
@@ -189,7 +189,7 @@ def test_freq_table():
                                direction_bin_labels=['lowest', 'lower', 'mid', 'high'], return_data=True)
     assert (tab.columns == ['lowest', 'lower', 'mid', 'high']).all()
     assert tab.sum().round(6).to_dict() == {'lowest': 14.800378, 'lower': 9.95062, 'mid': 25.807943, 'high': 49.441059}
-    assert round(DATA.Spd40mN.mean(), 2) == round(bw.export.export._calc_mean_speed_of_freq_tab(tab), 2)
+    assert round(bw.export.export._calc_mean_speed_of_freq_tab(tab), 5) == round(6.764183652027738, 5)
 
     assert bw.freq_table(DATA.Spd40mN, DATA.Dir38mS, plot_bins=[0, 3, 6, 9, 12, 15, 41],
                          plot_labels=['0-3 m/s', '4-6 m/s', '7-9 m/s', '10-12 m/s', '13-15 m/s', '15+ m/s'],
@@ -225,13 +225,16 @@ def test_freq_table():
     assert 'Text' in str(fig_rose.get_default_bbox_extra_artists())
     assert 'Note: A coverage threshold value of 0.3 is set' in str(fig_rose.get_default_bbox_extra_artists()[1])
 
-    fig_rose = bw.freq_table(DATA.Spd40mN, DATA.Dir38mS, return_data=False, seasonal_adjustment=True,
-                             coverage_threshold=0.5)
+    fig_rose, freq_tbl_seas_adj = bw.freq_table(DATA.Spd40mN, DATA.Dir38mS, return_data=True,
+                                                seasonal_adjustment=True, coverage_threshold=0.5,
+                                                var_series_mean_target=DATA.Spd40mN.mean())
+    assert round(DATA.Spd40mN.mean(), 3) == round(bw.export.export._calc_mean_speed_of_freq_tab(freq_tbl_seas_adj), 3)
     assert 'is lower than the coverage threshold value of 0.5' in str(fig_rose.get_default_bbox_extra_artists()[1])
     assert 'Some months may have very little data coverage' in str(fig_rose.get_default_bbox_extra_artists()[1])
 
-    fig_rose = bw.freq_table(DATA.Spd40mN, DATA.Dir38mS, return_data=False, seasonal_adjustment=True,
-                             coverage_threshold=0.8)
+    fig_rose, freq_tbl_seas_adj = bw.freq_table(DATA.Spd40mN, DATA.Dir38mS, return_data=True, seasonal_adjustment=True,
+                                                coverage_threshold=0.8, var_series_mean_target=8.5)
+    assert round(8.5, 3) == round(bw.export.export._calc_mean_speed_of_freq_tab(freq_tbl_seas_adj), 3)
     assert 'is lower than the coverage threshold value of 0.8' in str(fig_rose.get_default_bbox_extra_artists()[1])
     assert 'Some months may have very little data coverage' not in str(fig_rose.get_default_bbox_extra_artists()[1])
 


### PR DESCRIPTION
@stephenholleran you can find below the updates made as part of this issue:

1. Add option to give target mean frequency distribution value to `freq_table`. If input `var_series_mean_target` is not None then the input `var_series` is scaled to the target value and the `_get_dist_matrix_by_dir_sector` functions are called in a while loop in order to get a closest match between the target mean and the mean of the frequency distribution. The closest match is found when:
    - percentage difference between target mean and mean of freq distribution is < 0.01%
    - OR when a minimum difference is found, when the iteration goes in a infinite loop where it cannot converge - fluctuate between the same values
1.  No scaling  of the `freq_table` is applied when `var_series_mean_target` is None. No changes respect the previous version of this function
2. Add error raised when max of `var_series` or scaled value is > than max of `var_bin_array` input. This because we want the frequency distribution to capture the full range of `var_series` input
3. Fixed bug for `_calc_mean_speed_of_freq_tab` . This was already fixed in #359 but as this issue is not merged yet to dev then I had to replicate this fix
4. Added tests for the `var_series_mean_target` input option in `test_analyse`

Happy to discuss