### PR TITLE
[Iss325] solve resample warning

### DIFF
--- a/brightwind/transform/transform.py
+++ b/brightwind/transform/transform.py
@@ -398,7 +398,7 @@ def average_data_by_period(data, period, wdir_column_names=None, aggregation_met
             raise ValueError("The time period specified is less than the temporal resolution of the data. "
                              "For example, hourly data should not be averaged to 10 minute data.")
     data = data.sort_index()
-    grouper_obj = data.resample(period, axis=0, closed='left', label='left', base=0,
+    grouper_obj = data.resample(period, axis=0, closed='left', label='left',
                                 convention='start', kind='timestamp')
 
     # if period is equal to data resolution then no need to vector average wind direction

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -526,7 +526,7 @@ def test_average_data_by_period():
     data_monthly, coverage_monthly = bw.average_data_by_period(data_test, period='1M', wdir_column_names='Dir78mS',
                                                                return_coverage=True,
                                                                data_resolution=pd.DateOffset(minutes=10))
-    table_count = data_test.resample('1MS', axis=0, closed='left', label='left', base=0,
+    table_count = data_test.resample('1MS', axis=0, closed='left', label='left',
                                      convention='start', kind='timestamp').count()
     assert (table_count['Dir78mS']['2016-01-01'] / (31 * 24 * 6) - coverage_monthly['Dir78mS_Coverage']['2016-01-01']
             ) < 1e-5


### PR DESCRIPTION
- solved deprecation warning raised for Pandas v.1+ when `base` input is given to `pandas.resample` function 
- this was solved removing the `base` input as both pandas version < 1 and >1 are assuming this setting by default 
- I did a test for different resampling periods to check this