### PR TITLE
[Iss355] updated brighthub url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ _line_colors_, _legend_ and _figure_size_. (Issue #[349](https://github.com/brig
 11. Address errors and warnings generated for `Shear.TimeOfDay` and `Shear` when pandas >=1.0.0 (Issue #[347](https://github.com/brightwind-dev/brightwind/issues/347)).
 12. In `average_data_by_period()` fixed issue when wind direction average is derived for a period equal to the data resolution period (Issue #[319](https://github.com/brightwind-dev/brightwind/issues/319)).
 13. In `_calc_mean_speed_of_freq_tab` for `export_tab_file` fix issue around using wind speed bins less than 1 m/s (Issue #[359](https://github.com/brightwind-dev/brightwind/issues/359)).
+14. Updated `LoadBrightHub` URL and generalised functions used for connecting to BrightHub platform without using `boto3` (Issue #[355](https://github.com/brightwind-dev/brightwind/issues/355)).
 
 
 

--- a/brightwind/load/load.py
+++ b/brightwind/load/load.py
@@ -1017,13 +1017,13 @@ class _BrighthubAuth:
                 return ImportError(_BrighthubAuth.__BRIGHTHUB_LOGIN_ERROR_MAP["unexpected_error"])
 
         id_token = login_response['AuthenticationResult']['IdToken']
+        _BrighthubAuth.ID_TOKEN = id_token
         new_refresh_token = ""
 
         # refresh token only expires after 30 days, it is not returned in the response if it is still valid
         if login_response['AuthenticationResult'].get('RefreshToken'):
             new_refresh_token = login_response['AuthenticationResult']['RefreshToken']
 
-        _BrighthubAuth.ID_TOKEN = id_token
         # add the refresh token only if it has been generated again
         # this functionality hasn't been tested as we could not replicate an expired refresh token
         if new_refresh_token:
@@ -1215,7 +1215,7 @@ class LoadBrightHub:
         elif plant_uuid is not None and measurement_station_uuid is None:
             # get all for plant_uuid
             measurement_locations = LoadBrightHub._brighthub_request(url_end="/measurement-locations",
-                                                                       params={'plant_uuid': plant_uuid})
+                                                                     params={'plant_uuid': plant_uuid})
         elif measurement_station_uuid is not None:
             # get for measurement_station_uuid
             measurement_locations = LoadBrightHub._brighthub_request(

--- a/brightwind/load/load.py
+++ b/brightwind/load/load.py
@@ -1152,7 +1152,8 @@ class LoadBrightHub:
 
         To get the data model for a specific measurement station
         ::
-            data_model_json - bw.LoadBrightHub.get_data_model(measurement_station_uuid='9344e576-6d5a-45f0-9750-2a7528ebfa14')
+            data_model_json - bw.LoadBrightHub.get_data_model(
+                                                    measurement_station_uuid='9344e576-6d5a-45f0-9750-2a7528ebfa14')
 
         Using the data model
         ::
@@ -1278,7 +1279,7 @@ class LoadBrightHub:
                        date_to_dt.strftime(LoadBrightHub.__DATE_FORMAT))]
 
         def get_chunk(_date_from, _date_to, _id_token):
-            response = requests.get("https://api.brightwindhub.com/resource-data",
+            response = requests.get("{}/resource-data".format(LoadBrightHub.__BASE_URI),
                                     params={"measurement_location_uuid": measurement_station_uuid,
                                             "date_from": _date_from, "date_to": _date_to},
                                     headers={"authorization": _id_token})

--- a/brightwind/load/load.py
+++ b/brightwind/load/load.py
@@ -1043,7 +1043,7 @@ class LoadBrightHub:
     LoadBrightHub allows you to pull meta data and timeseries data of measurements from the BrightHub
     platform. This is a fast way to get access to the available open datasets on the platform.
 
-    To use LoadBrightHub, first sign up on www.brightwindhub.com and note your email and password.
+    To use LoadBrightHub, first sign up on www.brighthub.io and note your email and password.
 
     For security purposes LoadBrightHub uses stored environmental variables for your log in details. The
     BRIGHTHUB_EMAIL and BRIGHTHUB_PASSWORD environmental variables need to be set. In Windows this can be
@@ -1116,7 +1116,7 @@ class LoadBrightHub:
         :return:           A table showing the available plants.
         :rtype:            pd.DataFrame
 
-        To use LoadBrightHub, first sign up on www.brightwindhub.com and note your email and password.
+        To use LoadBrightHub, first sign up on www.brighthub.io and note your email and password.
 
         For security purposes LoadBrightHub uses stored environmental variables for your log in details. The
         BRIGHTHUB_EMAIL and BRIGHTHUB_PASSWORD environmental variables need to be set. In Windows this can be
@@ -1185,7 +1185,7 @@ class LoadBrightHub:
         :return:                         A table showing the available measurement stations.
         :rtype:                          pd.DataFrame
 
-        To use LoadBrightHub, first sign up on www.brightwindhub.com and note your email and password.
+        To use LoadBrightHub, first sign up on www.brighthub.io and note your email and password.
 
         For security purposes LoadBrightHub uses stored environmental variables for your log in details. The
         BRIGHTHUB_EMAIL and BRIGHTHUB_PASSWORD environmental variables need to be set. In Windows this can be
@@ -1334,10 +1334,6 @@ class LoadBrightHub:
         **Example usage**
         ::
             import brightwind as bw
-
-        To get all available measurement stations to pick out the measurement station's uuid
-        ::
-            bw.LoadBrightHub.get_measurement_stations()
 
         To get all the data for the specific measurement station
         ::

--- a/brightwind/load/load.py
+++ b/brightwind/load/load.py
@@ -1360,13 +1360,8 @@ class LoadBrightHub:
 
         """
         if not date_from or not date_to:
-            # Duplicating calling for start-end-time so I don't ending up getting an id_token again if I
-            # call get_start_end_dates().
-            # We will replace once we get code to check if the token has expired.
-            start_end_dates = LoadBrightHub._brighthub_request(
-                url_end="/start-end-dates/{}".format(measurement_station_uuid))
+            start_end_dates = LoadBrightHub.get_start_end_dates(measurement_station_uuid)
 
-            start_end_dates = start_end_dates.json()
             if not date_from:
                 date_from = start_end_dates['start_date']
             if not date_to:

--- a/brightwind/load/load.py
+++ b/brightwind/load/load.py
@@ -1284,10 +1284,6 @@ class LoadBrightHub:
         ::
             import brightwind as bw
 
-        To get all available measurement stations
-        ::
-            bw.LoadBrightHub.get_measurement_stations()
-
         To get the data model for a specific measurement station
         ::
             data_model_json - bw.LoadBrightHub.get_data_model(

--- a/brightwind/load/load.py
+++ b/brightwind/load/load.py
@@ -925,7 +925,7 @@ class LoadBrightHub:
     """
     # SHOULD I INITIATE BY GETTING ID-TOKEN? CAN INITIALISE BY SENDING A USERNAME, PASSWORD.
     # IF I INITIATE IT NEEDS TO BE ASSIGNED TO SOMETHING.
-    __BASE_URI = 'https://api.brightwindhub.com'
+    __BASE_URI = 'https://api.brighthub.io'
     # __BASE_URI = 'http://localhost:5000/'
 
     @staticmethod

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,5 @@ python-dateutil >= 2.8.0
 ipywidgets      >= 7.4.2
 ipython         >= 7.4.0
 gmaps           >= 0.9.0
-boto3           >= 1.9.66
 colormap        >= 1.0.1
 easydev         >= 0.10.0

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ setup(
         'ipywidgets>=7.4.2',
         'ipython>=7.4.0',
         'gmaps>=0.9.0',
-        'boto3>=1.9.66',
         'colormap>=1.0.1',
         'easydev>=0.10.0'
     ],

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -61,3 +61,33 @@ def test_load_campbell_scientific():
 
     assert (data['2016-01-09 15:30:00':'2016-01-10 23:50:00'].fillna(-999) ==
             data1['2016-01-09 15:30:00':'2016-01-10 23:50:00'].fillna(-999)).all().all()
+
+
+def test_load_brighthub():
+
+    plant_uuid = '715e5518-4f3a-4eb2-87cf-69547789232a'
+    measurement_station_uuid = '0cfd9da4-19d3-4cac-b5ab-4b8f35bac19b'
+    test_period_demo_data = {'start_date': '2009-12-01T17:40:00', 'end_date': '2012-03-10T00:00:00'}
+
+    # To get a specific plant
+    assert bw.LoadBrightHub.get_plants(plant_uuid=plant_uuid)[
+               'plant_type_id'].values[0] == 'onshore_wind'
+
+    # To get a specific measurement station
+    assert (bw.LoadBrightHub.get_measurement_stations(plant_uuid=plant_uuid).dropna(
+        axis=1) == bw.LoadBrightHub.get_measurement_stations(measurement_station_uuid=measurement_station_uuid
+                                                             ).dropna(axis=1)).all().all()
+
+    # To get the data model for a specific measurement station
+    assert bw.LoadBrightHub.get_data_model(measurement_station_uuid=measurement_station_uuid
+                                           )['author'] == 'Brighthub'
+
+    # To get start and end date of data for a specific measurement station
+    assert bw.LoadBrightHub.get_start_end_dates(measurement_station_uuid=measurement_station_uuid
+                                                ) == test_period_demo_data
+
+    # To get data for a specific time period for a specific measurement station
+    data_columns = bw.LoadBrightHub.get_data(measurement_station_uuid=measurement_station_uuid, date_from='2009-12-01',
+                                             date_to='2010-01-01').columns
+    for col in ['Spd1_60m270', 'Spd2_60m180', 'Dir1_58m']:
+        assert col in data_columns


### PR DESCRIPTION
The following updates were made for `LoadBrightHub`:

1. Updated URL
2. Updated `_get_id_token` function to don't use `boto3`. This function was also updated to return specific errors depending on the response. 
3. Updated method to get id_token  only once
4. Added `_brighthub_refresh_token` function to return a new token if the current id_token has expired.  This function will return specific errors depending on the response
5. Added generic function `_brighthub_request` to make a GET request to the Brighthub endpoints
6. Updated the following functions to use the generic `_brighthub_request` above:  `get_plants`, `get_measurement_stations`, `get_start_end_dates`, `get_data_model`, `get_data`, `get_chunk`
7. Added tests
8. Updated Changelog