### PR TITLE
[Iss370] fix demo wra data file

### DIFF
--- a/brightwind/demo_datasets/__init__.py
+++ b/brightwind/demo_datasets/__init__.py
@@ -10,6 +10,7 @@ __all__ = ['demo_data',
            'demo_windographer_flagging_log',
            'demo_windographer_flagging_log2',
            'demo_cleaning_file',
+           'demo_wra_data_model',
            'iea43_wra_data_model_schema_v1_0',
            'iea43_wra_data_model_v1_0',
            'iea43_wra_data_model_schema_v1_2',
@@ -27,6 +28,8 @@ demo_merra2_SW = os.path.join(os.path.dirname(__file__), 'MERRA-2_SW_2000-01-01_
 demo_windographer_flagging_log = os.path.join(os.path.dirname(__file__), 'windographer_flagging_log.txt')
 demo_windographer_flagging_log2 = os.path.join(os.path.dirname(__file__), 'windographer_flagging_log2.txt')
 demo_cleaning_file = os.path.join(os.path.dirname(__file__), 'demo_cleaning_file.csv')
+
+demo_wra_data_model = os.path.join(os.path.dirname(__file__), 'demo_data_iea43_wra_data_model.json')
 
 iea43_wra_data_model_schema_v1_0 = os.path.join(os.path.dirname(__file__), 'iea43_wra_data_model.schema_v1_0.json')
 iea43_wra_data_model_v1_0 = os.path.join(os.path.dirname(__file__), 'iea43_wra_data_model_v1_0.json')

--- a/brightwind/demo_datasets/demo_data_iea43_wra_data_model.json
+++ b/brightwind/demo_datasets/demo_data_iea43_wra_data_model.json
@@ -1,0 +1,1290 @@
+{
+  "author": "Bianca Morandi",
+  "organisation": "BrightWind",
+  "date": "2023-02-03",
+  "version": "1.0.0-2022.01",
+  "plant_name": "Demo Site",
+  "plant_type": "onshore_wind",
+  "measurement_location": [
+    {
+      "name": "Demo Mast",
+      "latitude_ddeg": 53.3049,
+      "longitude_ddeg": -6.212,
+      "measurement_station_type_id": "mast",
+      "notes": "A fabricated dataset located at our office.",
+      "update_at": "2021-02-24T17:04:34",
+      "mast_properties": {
+        "mast_geometry_id": "lattice_triangle",
+        "mast_oem": "A Mast Manufacturer",
+        "mast_serial_number": "MM01234",
+        "mast_model": "SLX80m",
+        "mast_height_m": 78.5,
+        "notes": "I can write anything I want here.",
+        "update_at": "2021-02-24T17:04:34",
+        "mast_section_geometry": [{
+          "uuid": "bf078172-bbb6-48fe-ac1f-c6605dffb1b5",
+          "pole_diameter_mm": null,
+          "lattice_face_width_at_bottom_mm": 500,
+          "lattice_face_width_at_top_mm": 500,
+          "lattice_leg_width_mm": 50,
+          "lattice_leg_is_round_cross_section": true,
+          "lattice_bracing_member_diameter_mm": 12,
+          "lattice_number_of_diagonal_bracing_members": 2,
+          "lattice_bracing_member_height_mm": 900,
+          "lattice_has_horizontal_member": false,
+          "notes": "I can write anything I want here.",
+          "update_at": "2021-02-24T17:04:34"
+        }]
+      },
+      "logger_main_config": [
+        {
+          "logger_serial_number": "1234567",
+          "logger_model_name": "CR1000",
+          "logger_id": "L1234567",
+          "logger_oem_id": "Campbell Scientific",
+          "logger_name": "demo",
+          "logger_firmware_version": "3.2.3",
+          "date_from": "2016-01-09T15:30:00",
+          "date_to": null,
+          "encryption_pin_or_key": null,
+          "enclosure_lock_details": null,
+          "data_transfer_details": null,
+          "offset_from_utc_hrs": null,
+          "sampling_rate_sec": 3,
+          "averaging_period_minutes": 10,
+          "timestamp_is_end_of_period": null,
+          "clock_is_auto_synced": null,
+          "logger_acquisition_uncertainty": 0.1,
+          "notes": null,
+          "update_at": "2021-02-24T17:04:34"
+        }
+      ],
+      "measurement_point": [
+        {
+          "name": "Spd80mN",
+          "measurement_type_id": "wind_speed",
+          "height_m": 80,
+          "height_reference_id": "ground_level",
+          "notes": null,
+          "update_at": "2021-02-24T17:04:35",
+          "mounting_arrangement": [
+            {
+              "mast_section_geometry_uuid": null,
+              "mounting_type_id": "side",
+              "boom_orientation_deg": 360,
+              "vane_dead_band_orientation_deg": null,
+              "orientation_reference_id": "magnetic_north",
+              "tilt_angle_deg": null,
+              "boom_oem": null,
+              "boom_model": null,
+              "upstand_height_mm": null,
+              "upstand_diameter_mm": null,
+              "boom_diameter_mm": null,
+              "boom_length_mm": null,
+              "distance_from_mast_to_sensor_mm": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:35"
+            }
+          ],
+          "sensor": [
+            {
+              "oem": "Thies",
+              "model": "First Class Advanced",
+              "serial_number": "0654321",
+              "sensor_type_id": "anemometer",
+              "classification": "1.2A",
+              "instrument_poi_height_mm": null,
+              "is_heated": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:37",
+              "calibration": [
+                {
+                  "measurement_type_id": "wind_speed",
+                  "slope": 0.046,
+                  "offset": 0.243,
+                  "sensitivity": null,
+                  "report_file_name": "Test Report",
+                  "report_link": null,
+                  "date_of_calibration": "2015-08-19",
+                  "revision": "A",
+                  "calibration_organisation": "Deutsche WindGuard",
+                  "place_of_calibration": null,
+                  "uncertainty_k_factor": null,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:37",
+                  "calibration_uncertainty": [{
+                      "reference_bin": 4,
+                      "reference_unit": "m/s",
+                      "combined_uncertainty": 0.1
+                    },{
+                      "reference_bin": 5.93,
+                      "reference_unit": "m/s",
+                      "combined_uncertainty": 0.1
+                    },{
+                      "reference_bin": 7.93,
+                      "reference_unit": "m/s",
+                      "combined_uncertainty": 0.1
+                    },{
+                      "reference_bin": 9.92,
+                      "reference_unit": "m/s",
+                      "combined_uncertainty": 0.1
+                    },{
+                      "reference_bin": 11.9,
+                      "reference_unit": "m/s",
+                      "combined_uncertainty": 0.1
+                    },{
+                      "reference_bin": 13.88,
+                      "reference_unit": "m/s",
+                      "combined_uncertainty": 0.1
+                    },{
+                      "reference_bin": 15.88,
+                      "reference_unit": "m/s",
+                      "combined_uncertainty": 0.1
+                    },{
+                      "reference_bin": 14.88,
+                      "reference_unit": "m/s",
+                      "combined_uncertainty": 0.1
+                    },{
+                      "reference_bin": 12.88,
+                      "reference_unit": "m/s",
+                      "combined_uncertainty": 0.1
+                    },{
+                      "reference_bin": 10.91,
+                      "reference_unit": "m/s",
+                      "combined_uncertainty": 0.1
+                    },{
+                      "reference_bin": 8.91,
+                      "reference_unit": "m/s",
+                      "combined_uncertainty": 0.1
+                    },{
+                      "reference_bin": 6.92,
+                      "reference_unit": "m/s",
+                      "combined_uncertainty": 0.1
+                    },{
+                      "reference_bin": 4.98,
+                      "reference_unit": "m/s",
+                      "combined_uncertainty": 0.1
+                  }]
+                }
+              ]
+            }
+          ],
+          "logger_measurement_config": [
+            {
+              "slope": 0.046,
+              "offset": 0.243,
+              "sensitivity": null,
+              "measurement_units_id": "m/s",
+              "height_m": 80,
+              "serial_number": "0654321",
+              "connection_channel": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:39",
+              "column_name": [
+                {
+                  "column_name": "Spd80mNStd",
+                  "statistic_type_id": "sd",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:39"
+                },
+                {
+                  "column_name": "Spd80mN",
+                  "statistic_type_id": "avg",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:39"
+                },
+                {
+                  "column_name": "Spd80mNMax",
+                  "statistic_type_id": "max",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:39"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Spd80mS",
+          "measurement_type_id": "wind_speed",
+          "height_m": 80,
+          "height_reference_id": "ground_level",
+          "notes": null,
+          "update_at": "2021-02-24T17:04:35",
+          "mounting_arrangement": [
+            {
+              "mast_section_geometry_uuid": null,
+              "mounting_type_id": "side",
+              "boom_orientation_deg": 180,
+              "vane_dead_band_orientation_deg": null,
+              "orientation_reference_id": "magnetic_north",
+              "tilt_angle_deg": null,
+              "boom_oem": null,
+              "boom_model": null,
+              "upstand_height_mm": null,
+              "upstand_diameter_mm": null,
+              "boom_diameter_mm": null,
+              "boom_length_mm": null,
+              "distance_from_mast_to_sensor_mm": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:35"
+            }
+          ],
+          "sensor": [
+            {
+              "oem": "Met One Instruments",
+              "model": "40C",
+              "serial_number": "02468",
+              "sensor_type_id": "anemometer",
+              "instrument_poi_height_mm": null,
+              "is_heated": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:37",
+              "calibration": [
+                {
+                  "slope": 0.84449,
+                  "offset": 0.3209,
+                  "sensitivity": null,
+                  "report_file_name": "Test Report",
+                  "report_link": null,
+                  "date_of_calibration": "2015-12-22",
+                  "calibration_organisation": "Deutsche WindGuard",
+                  "place_of_calibration": null,
+                  "uncertainty_k_factor": null,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:37"
+                }
+              ]
+            }
+          ],
+          "logger_measurement_config": [
+            {
+              "slope": 0.8445,
+              "offset": 0.321,
+              "sensitivity": null,
+              "measurement_units_id": "m/s",
+              "height_m": 80,
+              "serial_number": "02468",
+              "connection_channel": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:39",
+              "column_name": [
+                {
+                  "column_name": "Spd80mS",
+                  "statistic_type_id": "avg",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:39"
+                },
+                {
+                  "column_name": "Spd80mSMax",
+                  "statistic_type_id": "max",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:39"
+                },
+                {
+                  "column_name": "Spd80mSStd",
+                  "statistic_type_id": "sd",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:39"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Spd60mN",
+          "measurement_type_id": "wind_speed",
+          "height_m": 60,
+          "height_reference_id": "ground_level",
+          "notes": null,
+          "update_at": "2021-02-24T17:04:35",
+          "mounting_arrangement": [
+            {
+              "mast_section_geometry_uuid": null,
+              "mounting_type_id": "side",
+              "boom_orientation_deg": 360,
+              "vane_dead_band_orientation_deg": null,
+              "orientation_reference_id": "magnetic_north",
+              "tilt_angle_deg": null,
+              "boom_oem": null,
+              "boom_model": null,
+              "upstand_height_mm": null,
+              "upstand_diameter_mm": null,
+              "boom_diameter_mm": null,
+              "boom_length_mm": null,
+              "distance_from_mast_to_sensor_mm": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:35"
+            }
+          ],
+          "sensor": [
+            {
+              "oem": "Thies",
+              "model": "First Class Advanced",
+              "serial_number": "0654322",
+              "sensor_type_id": "anemometer",
+              "instrument_poi_height_mm": null,
+              "is_heated": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:37",
+              "calibration": [
+                {
+                  "slope": 0.46049,
+                  "offset": 0.23739,
+                  "sensitivity": null,
+                  "report_file_name": "Test Report",
+                  "report_link": null,
+                  "date_of_calibration": "2015-12-22",
+                  "calibration_organisation": "Deutsche WindGuard",
+                  "place_of_calibration": null,
+                  "uncertainty_k_factor": null,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:37"
+                }
+              ]
+            }
+          ],
+          "logger_measurement_config": [
+            {
+              "slope": 0.4605,
+              "offset": 0.2374,
+              "sensitivity": null,
+              "measurement_units_id": "m/s",
+              "height_m": 59.9,
+              "serial_number": "0654322",
+              "connection_channel": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:40",
+              "column_name": [
+                {
+                  "column_name": "Spd60mNStd",
+                  "statistic_type_id": "sd",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:40"
+                },
+                {
+                  "column_name": "Spd60mNMax",
+                  "statistic_type_id": "max",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:40"
+                },
+                {
+                  "column_name": "Spd60mN",
+                  "statistic_type_id": "avg",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:40"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Spd60mS",
+          "measurement_type_id": "wind_speed",
+          "height_m": 60,
+          "height_reference_id": "ground_level",
+          "notes": null,
+          "update_at": "2021-02-24T17:04:35",
+          "mounting_arrangement": [
+            {
+              "mast_section_geometry_uuid": null,
+              "mounting_type_id": "side",
+              "boom_orientation_deg": 180,
+              "vane_dead_band_orientation_deg": null,
+              "orientation_reference_id": "magnetic_north",
+              "tilt_angle_deg": null,
+              "boom_oem": null,
+              "boom_model": null,
+              "upstand_height_mm": null,
+              "upstand_diameter_mm": null,
+              "boom_diameter_mm": null,
+              "boom_length_mm": null,
+              "distance_from_mast_to_sensor_mm": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:35"
+            }
+          ],
+          "sensor": [
+            {
+              "oem": "Thies",
+              "model": "First Class Advanced",
+              "serial_number": "05193265",
+              "sensor_type_id": "anemometer",
+              "instrument_poi_height_mm": null,
+              "is_heated": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:37",
+              "calibration": [
+                {
+                  "slope": 0.04567,
+                  "offset": 0.2557,
+                  "sensitivity": null,
+                  "report_file_name": "Test Report",
+                  "report_link": null,
+                  "date_of_calibration": "2015-12-22",
+                  "calibration_organisation": "Deutsche WindGuard",
+                  "place_of_calibration": null,
+                  "uncertainty_k_factor": null,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:37"
+                }
+              ]
+            }
+          ],
+          "logger_measurement_config": [
+            {
+              "slope": 0.04567,
+              "offset": 0.2557,
+              "sensitivity": null,
+              "measurement_units_id": "m/s",
+              "height_m": 40,
+              "serial_number": "05193265",
+              "connection_channel": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:40",
+              "column_name": [
+                {
+                  "column_name": "Spd60mS",
+                  "statistic_type_id": "avg",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:40"
+                },
+                {
+                  "column_name": "Spd60mSStd",
+                  "statistic_type_id": "sd",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:40"
+                },
+                {
+                  "column_name": "Spd60mSMax",
+                  "statistic_type_id": "max",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:40"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Spd40mN",
+          "measurement_type_id": "wind_speed",
+          "height_m": 40,
+          "height_reference_id": "ground_level",
+          "notes": null,
+          "update_at": "2021-02-24T17:04:35",
+          "mounting_arrangement": [
+            {
+              "mast_section_geometry_uuid": null,
+              "mounting_type_id": "side",
+              "boom_orientation_deg": 360,
+              "vane_dead_band_orientation_deg": null,
+              "orientation_reference_id": "magnetic_north",
+              "tilt_angle_deg": null,
+              "boom_oem": null,
+              "boom_model": null,
+              "upstand_height_mm": null,
+              "upstand_diameter_mm": null,
+              "boom_diameter_mm": null,
+              "boom_length_mm": null,
+              "distance_from_mast_to_sensor_mm": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:35"
+            }
+          ],
+          "sensor": [
+            {
+              "oem": "Met One Instruments",
+              "model": "40C",
+              "serial_number": "013457",
+              "sensor_type_id": "anemometer",
+              "instrument_poi_height_mm": null,
+              "is_heated": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:37",
+              "calibration": [
+                {
+                  "slope": 0.8446,
+                  "offset": 0.321,
+                  "sensitivity": null,
+                  "report_file_name": "Test Report",
+                  "report_link": null,
+                  "date_of_calibration": "2015-12-22",
+                  "calibration_organisation": "Deutsche WindGuard",
+                  "place_of_calibration": null,
+                  "uncertainty_k_factor": null,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:37"
+                }
+              ]
+            }
+          ],
+          "logger_measurement_config": [
+            {
+              "slope": 0.8446,
+              "offset": 0.321,
+              "sensitivity": null,
+              "measurement_units_id": "m/s",
+              "height_m": 40,
+              "serial_number": "013457",
+              "connection_channel": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:40",
+              "column_name": [
+                {
+                  "column_name": "Spd40mN",
+                  "statistic_type_id": "avg",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:40"
+                },
+                {
+                  "column_name": "Spd40mNStd",
+                  "statistic_type_id": "sd",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:40"
+                },
+                {
+                  "column_name": "Spd40mNMax",
+                  "statistic_type_id": "max",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:40"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Spd40mS",
+          "measurement_type_id": "wind_speed",
+          "height_m": 40,
+          "height_reference_id": "ground_level",
+          "notes": null,
+          "update_at": "2021-02-24T17:04:35",
+          "mounting_arrangement": [
+            {
+              "mast_section_geometry_uuid": null,
+              "mounting_type_id": "side",
+              "boom_orientation_deg": 180,
+              "vane_dead_band_orientation_deg": null,
+              "orientation_reference_id": "magnetic_north",
+              "tilt_angle_deg": null,
+              "boom_oem": null,
+              "boom_model": null,
+              "upstand_height_mm": null,
+              "upstand_diameter_mm": null,
+              "boom_diameter_mm": null,
+              "boom_length_mm": null,
+              "distance_from_mast_to_sensor_mm": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:35"
+            }
+          ],
+          "sensor": [
+            {
+              "oem": "Thies",
+              "model": "First Class Advanced",
+              "serial_number": "013456",
+              "sensor_type_id": "anemometer",
+              "instrument_poi_height_mm": null,
+              "is_heated": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:38",
+              "calibration": [
+                {
+                  "slope": 0.04591,
+                  "offset": 0.25539,
+                  "sensitivity": null,
+                  "report_file_name": "Test Report",
+                  "report_link": null,
+                  "date_of_calibration": "2015-12-22",
+                  "calibration_organisation": "Deutsche WindGuard",
+                  "place_of_calibration": null,
+                  "uncertainty_k_factor": null,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:38"
+                }
+              ]
+            }
+          ],
+          "logger_measurement_config": [
+            {
+              "slope": 0.0459,
+              "offset": 0.2554,
+              "sensitivity": null,
+              "measurement_units_id": "m/s",
+              "height_m": 59.9,
+              "serial_number": "013456",
+              "connection_channel": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": "2017-01-04T17:59:00",
+              "notes": null,
+              "update_at": "2021-02-24T17:04:41",
+              "column_name": [
+                {
+                  "column_name": "Spd40mS",
+                  "statistic_type_id": "avg",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:41"
+                },
+                {
+                  "column_name": "Spd40mSStd",
+                  "statistic_type_id": "sd",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:41"
+                },
+                {
+                  "column_name": "Spd40mSMax",
+                  "statistic_type_id": "max",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:41"
+                }
+              ]
+            },
+            {
+              "slope": 0.04591,
+              "offset": 0.25539,
+              "sensitivity": null,
+              "measurement_units_id": "m/s",
+              "height_m": 59.9,
+              "serial_number": "013456",
+              "connection_channel": null,
+              "date_from": "2017-01-04T18:00:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:41",
+              "column_name": [
+                {
+                  "column_name": "Spd40mS",
+                  "statistic_type_id": "avg",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:41"
+                },
+                {
+                  "column_name": "Spd40mSStd",
+                  "statistic_type_id": "sd",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:41"
+                },
+                {
+                  "column_name": "Spd40mSMax",
+                  "statistic_type_id": "max",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:41"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Dir78mS",
+          "measurement_type_id": "wind_direction",
+          "height_m": 78,
+          "height_reference_id": "ground_level",
+          "notes": null,
+          "update_at": "2021-02-24T17:04:36",
+          "mounting_arrangement": [
+            {
+              "mast_section_geometry_uuid": null,
+              "mounting_type_id": "side",
+              "boom_orientation_deg": 180,
+              "vane_dead_band_orientation_deg": 180,
+              "orientation_reference_id": "magnetic_north",
+              "tilt_angle_deg": null,
+              "boom_oem": null,
+              "boom_model": null,
+              "upstand_height_mm": null,
+              "upstand_diameter_mm": null,
+              "boom_diameter_mm": null,
+              "boom_length_mm": null,
+              "distance_from_mast_to_sensor_mm": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:36"
+            }
+          ],
+          "sensor": [
+            {
+              "oem": null,
+              "model": "First Class",
+              "serial_number": "098765",
+              "sensor_type_id": "wind_vane",
+              "instrument_poi_height_mm": null,
+              "is_heated": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:38"
+            }
+          ],
+          "logger_measurement_config": [
+            {
+              "slope": 0.351,
+              "offset": 180,
+              "sensitivity": null,
+              "measurement_units_id": "deg",
+              "height_m": 78,
+              "serial_number": "098765",
+              "connection_channel": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:41",
+              "column_name": [
+                {
+                  "column_name": "Dir78mS",
+                  "statistic_type_id": "avg",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:41"
+                },
+                {
+                  "column_name": "Dir78mSStd",
+                  "statistic_type_id": "sd",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:41"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Dir58mS",
+          "measurement_type_id": "wind_direction",
+          "height_m": 58,
+          "height_reference_id": "ground_level",
+          "notes": null,
+          "update_at": "2021-02-24T17:04:36",
+          "mounting_arrangement": [
+            {
+              "mast_section_geometry_uuid": null,
+              "mounting_type_id": "side",
+              "boom_orientation_deg": 180,
+              "vane_dead_band_orientation_deg": 0,
+              "orientation_reference_id": "magnetic_north",
+              "tilt_angle_deg": null,
+              "boom_oem": null,
+              "boom_model": null,
+              "upstand_height_mm": null,
+              "upstand_diameter_mm": null,
+              "boom_diameter_mm": null,
+              "boom_length_mm": null,
+              "distance_from_mast_to_sensor_mm": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:36"
+            }
+          ],
+          "sensor": [
+            {
+              "oem": null,
+              "model": "First Class",
+              "serial_number": "0587654",
+              "sensor_type_id": "wind_vane",
+              "instrument_poi_height_mm": null,
+              "is_heated": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": "2017-01-04T17:59:00",
+              "notes": null,
+              "update_at": "2021-02-24T17:04:38"
+            },
+            {
+              "oem": null,
+              "model": "First Class",
+              "serial_number": "0587655",
+              "sensor_type_id": "wind_vane",
+              "instrument_poi_height_mm": null,
+              "is_heated": null,
+              "date_from": "2017-01-04T18:00:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:38"
+            }
+          ],
+          "logger_measurement_config": [
+            {
+              "slope": 0.351,
+              "offset": 0,
+              "sensitivity": null,
+              "measurement_units_id": "deg",
+              "height_m": 58,
+              "serial_number": "0587654",
+              "connection_channel": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": "2017-01-04T17:59:00",
+              "notes": null,
+              "update_at": "2021-02-24T17:04:42",
+              "column_name": [
+                {
+                  "column_name": "Dir58mSStd",
+                  "statistic_type_id": "sd",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:42"
+                },
+                {
+                  "column_name": "Dir58mS",
+                  "statistic_type_id": "avg",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:42"
+                }
+              ]
+            },
+            {
+              "slope": 0.351,
+              "offset": 0,
+              "sensitivity": null,
+              "measurement_units_id": "deg",
+              "height_m": 58,
+              "serial_number": "0587655",
+              "connection_channel": null,
+              "date_from": "2017-01-04T18:00:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:42",
+              "column_name": [
+                {
+                  "column_name": "Dir58mSStd",
+                  "statistic_type_id": "sd",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:42"
+                },
+                {
+                  "column_name": "Dir58mS",
+                  "statistic_type_id": "avg",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:42"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Dir38mS",
+          "measurement_type_id": "wind_direction",
+          "height_m": 38,
+          "height_reference_id": "ground_level",
+          "notes": null,
+          "update_at": "2021-02-24T17:04:36",
+          "mounting_arrangement": [
+            {
+              "mast_section_geometry_uuid": null,
+              "mounting_type_id": "side",
+              "boom_orientation_deg": 180,
+              "vane_dead_band_orientation_deg": 0,
+              "orientation_reference_id": "magnetic_north",
+              "tilt_angle_deg": null,
+              "boom_oem": null,
+              "boom_model": null,
+              "upstand_height_mm": null,
+              "upstand_diameter_mm": null,
+              "boom_diameter_mm": null,
+              "boom_length_mm": null,
+              "distance_from_mast_to_sensor_mm": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:36"
+            }
+          ],
+          "sensor": [
+            {
+              "oem": "Met One Instruments",
+              "model": "024A",
+              "serial_number": "A4567",
+              "sensor_type_id": "wind_vane",
+              "instrument_poi_height_mm": null,
+              "is_heated": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:38"
+            }
+          ],
+          "logger_measurement_config": [
+            {
+              "slope": 0.351,
+              "offset": 0,
+              "sensitivity": null,
+              "measurement_units_id": "deg",
+              "height_m": 38.1,
+              "serial_number": "A4567",
+              "connection_channel": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:42",
+              "column_name": [
+                {
+                  "column_name": "Dir38mSStd",
+                  "statistic_type_id": "sd",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:42"
+                },
+                {
+                  "column_name": "Dir38mS",
+                  "statistic_type_id": "avg",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:42"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "T2m",
+          "measurement_type_id": "air_temperature",
+          "height_m": 2,
+          "height_reference_id": "ground_level",
+          "notes": null,
+          "update_at": "2021-02-24T17:04:36",
+          "mounting_arrangement": [
+            {
+              "mast_section_geometry_uuid": null,
+              "mounting_type_id": "side",
+              "boom_orientation_deg": null,
+              "vane_dead_band_orientation_deg": null,
+              "orientation_reference_id": "magnetic_north",
+              "tilt_angle_deg": null,
+              "boom_oem": null,
+              "boom_model": null,
+              "upstand_height_mm": null,
+              "upstand_diameter_mm": null,
+              "boom_diameter_mm": null,
+              "boom_length_mm": null,
+              "distance_from_mast_to_sensor_mm": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:36"
+            }
+          ],
+          "sensor": [
+            {
+              "oem": "Campbell Scientific",
+              "model": "CS215",
+              "serial_number": null,
+              "sensor_type_id": "hygrometer",
+              "instrument_poi_height_mm": null,
+              "is_heated": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:38"
+            }
+          ],
+          "logger_measurement_config": [
+            {
+              "slope": 1,
+              "offset": 0,
+              "sensitivity": null,
+              "measurement_units_id": "deg_C",
+              "height_m": 2,
+              "serial_number": null,
+              "connection_channel": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:42",
+              "column_name": [
+                {
+                  "column_name": "T2m",
+                  "statistic_type_id": "avg",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:42"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "P2m",
+          "measurement_type_id": "air_pressure",
+          "height_m": 2,
+          "height_reference_id": "ground_level",
+          "notes": null,
+          "update_at": "2021-02-24T17:04:36",
+          "mounting_arrangement": [
+            {
+              "mast_section_geometry_uuid": null,
+              "mounting_type_id": "side",
+              "boom_orientation_deg": null,
+              "vane_dead_band_orientation_deg": null,
+              "orientation_reference_id": "magnetic_north",
+              "tilt_angle_deg": null,
+              "boom_oem": null,
+              "boom_model": null,
+              "upstand_height_mm": null,
+              "upstand_diameter_mm": null,
+              "boom_diameter_mm": null,
+              "boom_length_mm": null,
+              "distance_from_mast_to_sensor_mm": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:36"
+            }
+          ],
+          "sensor": [
+            {
+              "oem": "Vaisala",
+              "model": "PTB110",
+              "serial_number": null,
+              "sensor_type_id": "barometer",
+              "instrument_poi_height_mm": null,
+              "is_heated": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:38"
+            }
+          ],
+          "logger_measurement_config": [
+            {
+              "slope": 0.5,
+              "offset": 600,
+              "sensitivity": null,
+              "measurement_units_id": "mbar",
+              "height_m": null,
+              "serial_number": null,
+              "connection_channel": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:43",
+              "column_name": [
+                {
+                  "column_name": "P2m",
+                  "statistic_type_id": "avg",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:43"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "RH2m",
+          "measurement_type_id": "relative_humidity",
+          "height_m": 2,
+          "height_reference_id": "ground_level",
+          "notes": null,
+          "update_at": "2021-02-24T17:04:36",
+          "mounting_arrangement": [
+            {
+              "mast_section_geometry_uuid": null,
+              "mounting_type_id": "side",
+              "boom_orientation_deg": null,
+              "vane_dead_band_orientation_deg": null,
+              "orientation_reference_id": "magnetic_north",
+              "tilt_angle_deg": null,
+              "boom_oem": null,
+              "boom_model": null,
+              "upstand_height_mm": null,
+              "upstand_diameter_mm": null,
+              "boom_diameter_mm": null,
+              "boom_length_mm": null,
+              "distance_from_mast_to_sensor_mm": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:36"
+            }
+          ],
+          "sensor": [
+            {
+              "oem": "Campbell Scientific",
+              "model": "CS215",
+              "serial_number": null,
+              "sensor_type_id": "hygrometer",
+              "instrument_poi_height_mm": null,
+              "is_heated": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:38"
+            }
+          ],
+          "logger_measurement_config": [
+            {
+              "slope": 1,
+              "offset": 0,
+              "sensitivity": null,
+              "measurement_units_id": "%",
+              "height_m": null,
+              "serial_number": null,
+              "connection_channel": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:42",
+              "column_name": [
+                {
+                  "column_name": "RH2m",
+                  "statistic_type_id": "avg",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:42"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "BattMin",
+          "measurement_type_id": "voltage",
+          "height_m": null,
+          "height_reference_id": "ground_level",
+          "notes": null,
+          "update_at": "2021-02-24T17:04:37",
+          "sensor": [
+            {
+              "oem": "Ammonit",
+              "model": null,
+              "serial_number": null,
+              "sensor_type_id": "voltmeter",
+              "instrument_poi_height_mm": null,
+              "is_heated": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:39"
+            }
+          ],
+          "logger_measurement_config": [
+            {
+              "slope": null,
+              "offset": null,
+              "sensitivity": null,
+              "measurement_units_id": "V",
+              "height_m": null,
+              "serial_number": null,
+              "connection_channel": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:43",
+              "column_name": [
+                {
+                  "column_name": "BattMin",
+                  "statistic_type_id": "min",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:43"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "PrcpTot",
+          "measurement_type_id": "precipitation",
+          "height_m": null,
+          "height_reference_id": "ground_level",
+          "notes": null,
+          "update_at": "2021-02-24T17:04:36",
+          "sensor": [
+            {
+              "oem": null,
+              "model": null,
+              "serial_number": null,
+              "sensor_type_id": "rain_gauge",
+              "instrument_poi_height_mm": null,
+              "is_heated": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:39"
+            }
+          ],
+          "logger_measurement_config": [
+            {
+              "slope": null,
+              "offset": null,
+              "sensitivity": null,
+              "measurement_units_id": "%",
+              "height_m": null,
+              "serial_number": null,
+              "connection_channel": null,
+              "date_from": "2016-01-09T15:30:00",
+              "date_to": null,
+              "notes": null,
+              "update_at": "2021-02-24T17:04:43",
+              "column_name": [
+                {
+                  "column_name": "PrcpTot",
+                  "statistic_type_id": "sum",
+                  "is_ignored": false,
+                  "notes": null,
+                  "update_at": "2021-02-24T17:04:43"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/brightwind/transform/transform.py
+++ b/brightwind/transform/transform.py
@@ -935,8 +935,8 @@ def apply_wspd_slope_offset_adj(data, measurements, inplace=False):
                 date_to_txt = date_to
 
             variables = {
-                'slope': 'sensor_config.slope',
-                'offset': 'sensor_config.offset',
+                'slope': 'logger_measurement_config.slope',
+                'offset': 'logger_measurement_config.offset',
                 'cal_slope': 'calibration.slope',
                 'cal_offset': 'calibration.offset'
             }
@@ -1092,7 +1092,7 @@ def apply_wind_vane_deadband_offset(data, measurements, inplace=False):
             deadband = wdir_prop.get('vane_dead_band_orientation_deg')
             date_from = wdir_prop['date_from']
             # Account for a logger offset
-            logger_offset = wdir_prop.get('sensor_config.offset')
+            logger_offset = wdir_prop.get('logger_measurement_config.offset')
             offset = deadband
             additional_comment_txt = 'to account for deadband'
             if logger_offset is not None and logger_offset != 0 and deadband is not None:


### PR DESCRIPTION
1. Added `demo_data_iea43_wra_data_model.json` file with settings specific to the demo dataset used for all tests
2. updated `apply_wspd_slope_offset_adj` and `apply_wind_vane_deadband_offset` functions to work with version >= 1.0 of IEA Taks-43 data model