### PR TITLE
[Iss335] deprecate plot freq distribution

### DIFF
--- a/brightwind/analyse/analyse.py
+++ b/brightwind/analyse/analyse.py
@@ -7,9 +7,10 @@ from brightwind.utils.utils import _convert_df_to_series
 from brightwind.utils.utils import validate_coverage_threshold
 from brightwind.export.export import _calc_mean_speed_of_freq_tab
 from brightwind.transform.transform import scale_wind_speed
-import matplotlib
+import matplotlib.pyplot as plt
 import warnings
 import textwrap
+from matplotlib.ticker import PercentFormatter
 
 __all__ = ['monthly_means',
            'momm',
@@ -453,10 +454,19 @@ def dist(var_to_bin, var_to_bin_against=None, bins=None, bin_labels=None, x_labe
     if not isinstance(aggregation_method, str):
         aggregation_method = aggregation_method.__name__
 
-    graph = bw_plt.plot_freq_distribution(distributions.replace([np.inf, -np.inf], np.NAN),
-                                          max_y_value=max_y_value,
-                                          x_tick_labels=bin_labels, x_label=x_label, y_label=aggregation_method,
-                                          legend=legend)
+    # Plot distribution
+    bar_tick_label_format = None
+    if aggregation_method:
+        if '%' in aggregation_method:
+            bar_tick_label_format = PercentFormatter()
+
+    graph = plt.figure(figsize=(15, 8))
+    ax = graph.add_axes([0.1, 0.1, 0.8, 0.8])
+    bw_plt._bar_subplot(distributions.replace([np.inf, -np.inf], np.NAN), x_label=x_label, y_label=aggregation_method,
+                        max_bar_axis_limit=max_y_value, bin_tick_labels=bin_labels,
+                        bar_tick_label_format=bar_tick_label_format, legend=legend, total_width=0.8, ax=ax)
+    plt.close()
+
     if bin_labels is not None:
         distributions.index = bin_labels
     if return_data:

--- a/brightwind/analyse/plot.py
+++ b/brightwind/analyse/plot.py
@@ -17,6 +17,7 @@ import six
 from colormap import rgb2hex, rgb2hls, hls2rgb
 from matplotlib.ticker import PercentFormatter
 from matplotlib.colors import ListedColormap, LinearSegmentedColormap
+import warnings
 
 register_matplotlib_converters()
 
@@ -1206,6 +1207,8 @@ def plot_freq_distribution(data, max_y_value=None, x_tick_labels=None, x_label=N
     or a Dataframe. If it is a Dataframe then the distribution is plotted for each column of the Dataframe and with
     a different colour for each dataset.
 
+    ** THIS FUNCTION WILL BE REMOVED IN A FUTURE VERSION OF BRIGHTWIND LIBRARY **
+
     :param data:            The input distribution derived using bw.analyse.analyse._derive_distribution().
     :type data:             pd.Series or pd.Dataframe
     :param max_y_value:     y-axis max limit. It can be set to None to let the code derive the max from
@@ -1252,6 +1255,10 @@ def plot_freq_distribution(data, max_y_value=None, x_tick_labels=None, x_label=N
                                                y_label='count', total_width=1, legend=True)
 
     """
+
+    warnings.warn(f"In a future version of brightwind, `plot_freq_distribution` will be removed. Please use "
+                  f"'dist()' or `_bar_subplot()` instead.", category=DeprecationWarning)
+
     bar_tick_label_format = None
     if y_label:
         if '%' in y_label:

--- a/brightwind/analyse/plot.py
+++ b/brightwind/analyse/plot.py
@@ -1256,8 +1256,8 @@ def plot_freq_distribution(data, max_y_value=None, x_tick_labels=None, x_label=N
 
     """
 
-    warnings.warn(f"In a future version of brightwind, `plot_freq_distribution` will be removed. Please use "
-                  f"'dist()' or `_bar_subplot()` instead.", category=DeprecationWarning)
+    warnings.warn("In a future version of brightwind, `plot_freq_distribution` will be removed. Please use "
+                  "'dist()' or `_bar_subplot()` instead.", category=FutureWarning)
 
     bar_tick_label_format = None
     if y_label:


### PR DESCRIPTION
As part of this issue I have:

1. Removed `plot_freq_distribution()` function from` dist()` and used `_bar_subplot` directly
2. Put a DeperactionWarning in `plot_freq_distribution `function