### PR TITLE
[Iss377] speedsort sector predict update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ _line_colors_, _legend_ and _figure_size_. (Issue #[349](https://github.com/brig
 14. Addressed all Future and Deprecation warnings for matplotlib<=3.6.3, numpy<=1.24.1, pandas<=1.5.3. (Issue #[356](https://github.com/brightwind-dev/brightwind/issues/356)).
 15. Update to work with versions 1.0 to 1.2 of IEA WIND Task 43 WRA Data Model (Issue #[306](https://github.com/brightwind-dev/brightwind/issues/306)).
 16. Updated `LoadBrightHub` URL and generalised functions used for connecting to BrightHub platform without using `boto3` (Issue #[355](https://github.com/brightwind-dev/brightwind/issues/355)).
-
+17: Fixed bug for `SpeedSort` where the `sector_predict` function was not interpolating data using two fit lines. (Issue #[377](https://github.com/brightwind-dev/brightwind/issues/377)).
 
 ## [2.0.0]
 - Major changes, notably

--- a/brightwind/analyse/correlation.py
+++ b/brightwind/analyse/correlation.py
@@ -832,12 +832,18 @@ class SpeedSort(CorrelBase):
             self.params = dict()
             self.params['slope'] = (ymean2 - ymean1) / (xmean2 - xmean1)
             self.params['offset'] = ymean1 - (xmean1 * self.params['slope'])
+            self.params['cutoff'] = cutoff
             # print(self.params)
 
         def sector_predict(self, x):
-            def linear_function(x, slope, offset):
-                return x * slope + offset
-            return x.transform(linear_function, slope=self.params['slope'], offset=self.params['offset'])
+            def bilinear_function(x, slope, offset, cutoff):
+                if x < cutoff:
+                    return (slope * cutoff + offset) * x / cutoff  # Line passing through zero
+                else:
+                    return x * slope + offset  # Line not passing through zero
+
+            return x.transform(bilinear_function, slope=self.params['slope'], offset=self.params['offset'],
+                               cutoff=self.params['cutoff'])
 
         def plot_model(self):
             return plot_scatter(self.sector_ref,

--- a/tests/test_correlation.py
+++ b/tests/test_correlation.py
@@ -287,6 +287,18 @@ def test_synthesize():
     assert (data_synt['Dir58mS_Synthesized']['2016-01-09 17:10:00':'2016-01-09 17:40:00']
             == data_test['Dir58mS']['2016-01-09 17:10:00':'2016-01-09 17:40:00']).all()
 
+    # Test SpeedSort prediction when used for speeds lower than the reference speed cutoff.
+    index_test = (ss_cor.data[ss_cor._ref_dir_col_name] > ss_cor.params[2]['sector_min']
+                  ) & (ss_cor.data[ss_cor._ref_dir_col_name] < ss_cor.params[2]['sector_max']
+                       ) & (ss_cor.data[ss_cor._ref_spd_col_name] < ss_cor.cutoff)
+
+    test_predict_below_cutoff = ((ss_cor.params[2]['slope'] * ss_cor.cutoff + ss_cor.params[2]['offset']) * ss_cor.data[
+        ss_cor._ref_spd_col_name][index_test] / ss_cor.cutoff)
+
+    assert ((1 - (test_predict_below_cutoff / (ss_cor._predict(ss_cor.data[ss_cor._ref_spd_col_name][index_test],
+                                                               ss_cor.data[ss_cor._ref_dir_col_name][index_test]))
+                  )) < 10 ** -5).all()
+
     # Test the synthesise when SpeedSort correlation is used and ref_dir and target_dir are the same
     ss_cor = bw.Correl.SpeedSort(data_test['Spd80mN'], data_test['Dir78mS'], data_test['Spd60mN'], data_test['Dir78mS'],
                                  averaging_prd='10min')


### PR DESCRIPTION
The `SpeedSort.speed_model.sector_predict` function was updated to consider two fit lines:

1. line passing through zero and the cut off reference speed -> used for reference speeds < cut off
2. best fit line of points above cut off reference speed -> used for speeds >= cut off