### PR TITLE
[Iss376] plot shear time of day colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,7 @@ _line_colors_, _legend_ and _figure_size_. (Issue #[349](https://github.com/brig
 13. In `_calc_mean_speed_of_freq_tab` for `export_tab_file` fix issue around using wind speed bins less than 1 m/s (Issue #[359](https://github.com/brightwind-dev/brightwind/issues/359)).
 14. Addressed all Future and Deprecation warnings for matplotlib<=3.6.3, numpy<=1.24.1, pandas<=1.5.3. (Issue #[356](https://github.com/brightwind-dev/brightwind/issues/356)).
 15. Update to work with versions 1.0 to 1.2 of IEA WIND Task 43 WRA Data Model (Issue #[306](https://github.com/brightwind-dev/brightwind/issues/306)).
-
-
-
+16. Updated color map used for `Shear.TimeOfDay` plots when `plot_type` is 'step' or 'line'. (Issue #[376](https://github.com/brightwind-dev/brightwind/issues/376)).
 
 
 ## [2.0.0]

--- a/brightwind/analyse/plot.py
+++ b/brightwind/analyse/plot.py
@@ -16,7 +16,7 @@ import re
 import six
 from colormap import rgb2hex, rgb2hls, hls2rgb
 from matplotlib.ticker import PercentFormatter
-from matplotlib.colors import ListedColormap, LinearSegmentedColormap
+from matplotlib.colors import ListedColormap, to_hex
 import warnings
 
 register_matplotlib_converters()
@@ -73,7 +73,14 @@ class _ColorPalette:
         _col_map_colors = [self.primary_95,  # lightest primary
                            self.primary,     # primary
                            self.primary_10]  # darkest primary
+
+        _col_map_symmetric_diverging_colors = [self.primary_10,  # dark green, 10% of primary
+                                               self.fifth,       # yellow'ish, rgb(242, 216, 105)
+                                               self.tertiary]    # red'ish, rgb(155, 43, 44)
+
         self._color_map = self._set_col_map(_col_map_colors)
+
+        self._col_map_symmetric_diverging = self._set_col_map(_col_map_symmetric_diverging_colors)
 
         self.color_list = [self.primary, self.secondary, self.tertiary, self.fourth, self.fifth, self.sixth,
                            self.seventh, self.eighth, self.ninth, self.tenth, self.eleventh, self.primary_35]
@@ -89,12 +96,23 @@ class _ColorPalette:
     def color_map(self):
         return self._color_map
 
+    @property
+    def col_map_symmetric_diverging(self):
+        return self._col_map_symmetric_diverging
+
     @color_map.setter
     def color_map(self, col_map_colors):
         self._color_map = self._set_col_map(col_map_colors)
 
 
 COLOR_PALETTE = _ColorPalette()
+
+
+def _colormap_to_colorscale(cmap, n_colors):
+    """
+    Function that transforms a matplotlib colormap to a list of colors
+    """
+    return [to_hex(cmap(k*0.1)) for k in range(n_colors)]
 
 
 def _adjust_color_lightness(r, g, b, factor):
@@ -1857,6 +1875,10 @@ def plot_log_law(avg_slope, avg_intercept, wspds, heights, max_plot_height=None)
 def plot_shear_time_of_day(df, calc_method, plot_type='step'):
     """
     Function used by Shear.TimeOfDay for plotting the hourly shear for each calendar month or an average of all months.
+    The color map used for plotting the shear by time of day for each calendar month depends on the plot_type input:
+        1) if 'line' 'step' the COLOR_PALETTE.col_map_symmetric_diverging is used
+        2) if '12x24' the 'COLOR_PALETTE.col_map is used
+    The color used for plotting the average of all months shear is COLOR_PALETTE.primary.
 
     :param df:          Series of average shear by time of day or DataFrame of shear by time of day for
                         each calendar month.
@@ -1870,54 +1892,27 @@ def plot_shear_time_of_day(df, calc_method, plot_type='step'):
 
     """
     df_copy = df.copy()
-    # colours in use
-    r, g, b = tuple(255 * np.array(mpl.colors.to_rgb(bw.analyse.plot.COLOR_PALETTE.primary)))
-    r1, g1, b1 = tuple(255 * np.array(mpl.colors.to_rgb(bw.analyse.plot.COLOR_PALETTE.tertiary)))
-    colors = [mpl.colors.to_rgb(bw.analyse.plot._adjust_color_lightness(r, g, b, factor=0.4)), #Jan
-              mpl.colors.to_rgb(bw.analyse.plot._adjust_color_lightness(r, g, b, factor=0.68)), #Feb
-              mpl.colors.to_rgb(bw.analyse.plot._adjust_color_lightness(r, g, b, factor=0.96)), #March
-              mpl.colors.to_rgb(bw.analyse.plot._adjust_color_lightness(r, g, b, factor=1.24)), #April
-              mpl.colors.to_rgb(bw.analyse.plot._adjust_color_lightness(r, g, b, factor=1.52)), #May
-              mpl.colors.to_rgb(bw.analyse.plot._adjust_color_lightness(r, g, b, factor=1.8)), #Jun
-              mpl.colors.to_rgb(bw.analyse.plot._adjust_color_lightness(r1, g1, b1, factor=1.8)), #July
-              mpl.colors.to_rgb(bw.analyse.plot._adjust_color_lightness(r1, g1, b1, factor=1.52)), #Aug
-              mpl.colors.to_rgb(bw.analyse.plot._adjust_color_lightness(r1, g1, b1, factor=1.24)), #Sep
-              mpl.colors.to_rgb(bw.analyse.plot._adjust_color_lightness(r1, g1, b1, factor=0.96)), #Oct
-              mpl.colors.to_rgb(bw.analyse.plot._adjust_color_lightness(r1, g1, b1, factor=0.68)), #Nov
-              mpl.colors.to_rgb(bw.analyse.plot._adjust_color_lightness(r1, g1, b1, factor=0.4))] #Dec
 
-    # colors = [(0.6313725490196078, 0.6470588235294118, 0.6705882352941176, 1.0),  # Jan
-    #           (0.1568627450980392, .19215686274509805, 0.6705882352941176, 1.0),  # Feb
-    #           (0.06666666666666667, 0.4196078431372549, 0.6901960784313725, 1.0),  # March
-    #           (0.22745098039215686, 0.7294117647058823, 0.9803921568627451, 1.0),  # April
-    #           (0.2392156862745098, 0.5666666666666667, 0.42745098039215684, 1.0),  # May
-    #           (0.4117647058823529, 0.7137254901960784, 0.16470588235294117, 1.0),  # June
-    #           (0.611764705882353, 0.7725490196078432, 0.21568627450980393, 1.0),  # July
-    #           (0.6823529411764706, 0.403921568627451, 0.1607843137254902, 1.0),  # Aug
-    #           (0.7901960784313726, 0.48627450980392156, 0.1843137254901961, 1.0),  # Sep
-    #           (1, 0.7019607843, .4, 1),  # Oct
-    #           (0, 0, 0, 1.0),  # Nov
-    #           (0.40588235294117647, 0.43137254901960786, 0.4666666666666667, 1.0)]  # Dec
-
-    if len(df.columns) == 1:
-        colors[0] = COLOR_PALETTE.primary
     if calc_method == 'power_law':
         label = 'Average Shear'
-
-    if calc_method == 'log_law':
+    elif calc_method == 'log_law':
         label = 'Roughness Coefficient'
+    else:
+        label = calc_method
 
     if plot_type == '12x24':
         df.columns = np.arange(1, 13, 1)
         df.index = np.arange(0, 24, 1)
-        df[df.columns[::-1]]
         return plot_12x24_contours(df, label=(label, 'mean'), plot='tod')
 
     else:
+        colors = _colormap_to_colorscale(COLOR_PALETTE.col_map_symmetric_diverging, 12)
+        if len(df.columns) == 1:
+            colors[0] = COLOR_PALETTE.primary
+
         fig, ax = plt.subplots(figsize=(10, 10))
         ax.set_xlabel('Time of Day')
         ax.set_ylabel(label)
-        import matplotlib.dates as mdates
 
         # create x values for plot
         idx = pd.date_range('2017-01-01 00:00', '2017-01-01 23:00', freq='1H').time

--- a/brightwind/analyse/plot.py
+++ b/brightwind/analyse/plot.py
@@ -104,6 +104,10 @@ class _ColorPalette:
     def color_map(self, col_map_colors):
         self._color_map = self._set_col_map(col_map_colors)
 
+    @color_map.setter
+    def col_map_symmetric_diverging(self, col_map_colors):
+        self._col_map_symmetric_diverging = self._set_col_map(col_map_colors)
+
 
 COLOR_PALETTE = _ColorPalette()
 

--- a/brightwind/analyse/plot.py
+++ b/brightwind/analyse/plot.py
@@ -1855,6 +1855,20 @@ def plot_log_law(avg_slope, avg_intercept, wspds, heights, max_plot_height=None)
 
 
 def plot_shear_time_of_day(df, calc_method, plot_type='step'):
+    """
+    Function used by Shear.TimeOfDay for plotting the hourly shear for each calendar month or an average of all months.
+
+    :param df:          Series of wind speed timeseries.
+    :type df:           pandas.Series
+    :param calc_method: method used by Shear.TimeOfDay for shear calculation, either 'power_law' or 'log_law'.
+                        Input used for defining label of y axis.
+    :type calc_method:  str
+    :param plot_type:   Type of plot to be generated. Options include 'line', 'step' and '12x24'. Default is 'step'.
+    :type plot_type:    str
+    :returns:           A shear by time of day plot
+
+    """
+    print(df)
     df_copy = df.copy()
     # colours in use
     colors = [(0.6313725490196078, 0.6470588235294118, 0.6705882352941176, 1.0),  # Jan

--- a/brightwind/analyse/plot.py
+++ b/brightwind/analyse/plot.py
@@ -1858,9 +1858,10 @@ def plot_shear_time_of_day(df, calc_method, plot_type='step'):
     """
     Function used by Shear.TimeOfDay for plotting the hourly shear for each calendar month or an average of all months.
 
-    :param df:          Series of wind speed timeseries.
-    :type df:           pandas.Series
-    :param calc_method: method used by Shear.TimeOfDay for shear calculation, either 'power_law' or 'log_law'.
+    :param df:          Series of average shear by time of day or DataFrame of shear by time of day for
+                        each calendar month.
+    :type df:           pandas.Series or pandas.DataFrame
+    :param calc_method: Method used by Shear.TimeOfDay for shear calculation, either 'power_law' or 'log_law'.
                         Input used for defining label of y axis.
     :type calc_method:  str
     :param plot_type:   Type of plot to be generated. Options include 'line', 'step' and '12x24'. Default is 'step'.
@@ -1868,24 +1869,38 @@ def plot_shear_time_of_day(df, calc_method, plot_type='step'):
     :returns:           A shear by time of day plot
 
     """
-    print(df)
     df_copy = df.copy()
     # colours in use
-    colors = [(0.6313725490196078, 0.6470588235294118, 0.6705882352941176, 1.0),  # Jan
-              (0.1568627450980392, .19215686274509805, 0.6705882352941176, 1.0),  # Feb
-              (0.06666666666666667, 0.4196078431372549, 0.6901960784313725, 1.0),  # March
-              (0.22745098039215686, 0.7294117647058823, 0.9803921568627451, 1.0),  # April
-              (0.2392156862745098, 0.5666666666666667, 0.42745098039215684, 1.0),  # May
-              (0.4117647058823529, 0.7137254901960784, 0.16470588235294117, 1.0),  # June
-              (0.611764705882353, 0.7725490196078432, 0.21568627450980393, 1.0),  # July
-              (0.6823529411764706, 0.403921568627451, 0.1607843137254902, 1.0),  # Aug
-              (0.7901960784313726, 0.48627450980392156, 0.1843137254901961, 1.0),  # Sep
-              (1, 0.7019607843, .4, 1),  # Oct
-              (0, 0, 0, 1.0),  # Nov
-              (0.40588235294117647, 0.43137254901960786, 0.4666666666666667, 1.0)]  # Dec
+    r, g, b = tuple(255 * np.array(mpl.colors.to_rgb(bw.analyse.plot.COLOR_PALETTE.primary)))
+    r1, g1, b1 = tuple(255 * np.array(mpl.colors.to_rgb(bw.analyse.plot.COLOR_PALETTE.tertiary)))
+    colors = [mpl.colors.to_rgb(bw.analyse.plot._adjust_color_lightness(r, g, b, factor=0.4)), #Jan
+              mpl.colors.to_rgb(bw.analyse.plot._adjust_color_lightness(r, g, b, factor=0.68)), #Feb
+              mpl.colors.to_rgb(bw.analyse.plot._adjust_color_lightness(r, g, b, factor=0.96)), #March
+              mpl.colors.to_rgb(bw.analyse.plot._adjust_color_lightness(r, g, b, factor=1.24)), #April
+              mpl.colors.to_rgb(bw.analyse.plot._adjust_color_lightness(r, g, b, factor=1.52)), #May
+              mpl.colors.to_rgb(bw.analyse.plot._adjust_color_lightness(r, g, b, factor=1.8)), #Jun
+              mpl.colors.to_rgb(bw.analyse.plot._adjust_color_lightness(r1, g1, b1, factor=1.8)), #July
+              mpl.colors.to_rgb(bw.analyse.plot._adjust_color_lightness(r1, g1, b1, factor=1.52)), #Aug
+              mpl.colors.to_rgb(bw.analyse.plot._adjust_color_lightness(r1, g1, b1, factor=1.24)), #Sep
+              mpl.colors.to_rgb(bw.analyse.plot._adjust_color_lightness(r1, g1, b1, factor=0.96)), #Oct
+              mpl.colors.to_rgb(bw.analyse.plot._adjust_color_lightness(r1, g1, b1, factor=0.68)), #Nov
+              mpl.colors.to_rgb(bw.analyse.plot._adjust_color_lightness(r1, g1, b1, factor=0.4))] #Dec
+
+    # colors = [(0.6313725490196078, 0.6470588235294118, 0.6705882352941176, 1.0),  # Jan
+    #           (0.1568627450980392, .19215686274509805, 0.6705882352941176, 1.0),  # Feb
+    #           (0.06666666666666667, 0.4196078431372549, 0.6901960784313725, 1.0),  # March
+    #           (0.22745098039215686, 0.7294117647058823, 0.9803921568627451, 1.0),  # April
+    #           (0.2392156862745098, 0.5666666666666667, 0.42745098039215684, 1.0),  # May
+    #           (0.4117647058823529, 0.7137254901960784, 0.16470588235294117, 1.0),  # June
+    #           (0.611764705882353, 0.7725490196078432, 0.21568627450980393, 1.0),  # July
+    #           (0.6823529411764706, 0.403921568627451, 0.1607843137254902, 1.0),  # Aug
+    #           (0.7901960784313726, 0.48627450980392156, 0.1843137254901961, 1.0),  # Sep
+    #           (1, 0.7019607843, .4, 1),  # Oct
+    #           (0, 0, 0, 1.0),  # Nov
+    #           (0.40588235294117647, 0.43137254901960786, 0.4666666666666667, 1.0)]  # Dec
 
     if len(df.columns) == 1:
-        colors[0] = colors[5]
+        colors[0] = COLOR_PALETTE.primary
     if calc_method == 'power_law':
         label = 'Average Shear'
 


### PR DESCRIPTION
The `plot_shear_time_of_day` function was updated to remove the hardcoded colors used when `plot_type` is 'line' of 'step'. The following enhancements are made:

- a new color map was added to COLOR_PALETTE, color_map_symmetric_diverging
- colors for `plot_shear_time_of_day` are now taken from COLOR_PALETTE, color_map_symmetric_diverging
- user can change the colors to use for the color map only redefining  COLOR_PALETTE.color_map_symmetric_diverging