### PR TITLE
[Iss298] momm seasonal adjusted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ _line_colors_, _legend_ and _figure_size_. (Issue #[349](https://github.com/brig
 16. Updated `LoadBrightHub` URL and generalised functions used for connecting to BrightHub platform without using `boto3` (Issue #[355](https://github.com/brightwind-dev/brightwind/issues/355)).
 17. Removed hardcoded colours for `Shear.TimeOfDay` plots when `plot_type` is 'step' or 'line' and added a colour map. (Issue #[376](https://github.com/brightwind-dev/brightwind/issues/376)).
 18: Fixed bug for `SpeedSort` where the `sector_predict` function was not interpolating data using two fit lines. (Issue #[377](https://github.com/brightwind-dev/brightwind/issues/377)).
+19: Allow `momm` function to derive a seasonal adjusted mean of monthly mean if user sets `seasonal_adjustment` to true. (Issue # [298](https://github.com/brightwind-dev/brightwind/issues/298))
 
 
 ## [2.0.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ _line_colors_, _legend_ and _figure_size_. (Issue #[349](https://github.com/brig
 16. Updated `LoadBrightHub` URL and generalised functions used for connecting to BrightHub platform without using `boto3` (Issue #[355](https://github.com/brightwind-dev/brightwind/issues/355)).
 17. Removed hardcoded colours for `Shear.TimeOfDay` plots when `plot_type` is 'step' or 'line' and added a colour map. (Issue #[376](https://github.com/brightwind-dev/brightwind/issues/376)).
 18: Fixed bug for `SpeedSort` where the `sector_predict` function was not interpolating data using two fit lines. (Issue #[377](https://github.com/brightwind-dev/brightwind/issues/377)).
-19: Allow `momm` function to derive a seasonal adjusted mean of monthly mean if user sets `seasonal_adjustment` to true. (Issue #[298](https://github.com/brightwind-dev/brightwind/issues/298))
+19: Allow `momm` function to derive a seasonal adjusted mean of monthly mean, if user sets `seasonal_adjustment` to true, and allow user to input a `coverage_threshold` (Issue #[298](https://github.com/brightwind-dev/brightwind/issues/298))
 
 
 ## [2.0.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ _line_colors_, _legend_ and _figure_size_. (Issue #[349](https://github.com/brig
 16. Updated `LoadBrightHub` URL and generalised functions used for connecting to BrightHub platform without using `boto3` (Issue #[355](https://github.com/brightwind-dev/brightwind/issues/355)).
 17. Removed hardcoded colours for `Shear.TimeOfDay` plots when `plot_type` is 'step' or 'line' and added a colour map. (Issue #[376](https://github.com/brightwind-dev/brightwind/issues/376)).
 18: Fixed bug for `SpeedSort` where the `sector_predict` function was not interpolating data using two fit lines. (Issue #[377](https://github.com/brightwind-dev/brightwind/issues/377)).
-19: Allow `momm` function to derive a seasonal adjusted mean of monthly mean, if user sets `seasonal_adjustment` to true, and allow user to input a `coverage_threshold` (Issue #[298](https://github.com/brightwind-dev/brightwind/issues/298))
+19: Allow `momm` function to derive a seasonal adjusted mean of monthly mean, if user sets `seasonal_adjustment` to true, and allow to apply a `coverage_threshold` (Issue #[298](https://github.com/brightwind-dev/brightwind/issues/298))
 
 
 ## [2.0.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,13 @@ Additional labels for pre-release and build metadata are available as extensions
 is not equal to the derived temporal resolution.
 2. Added `data_resolution` argument to `average_data_by_period`, `monthly_means`, `coverage` and 
   `merge_datasets_by_period` functions (Issue #[297](https://github.com/brightwind-dev/brightwind/issues/297))
-3. Update to work with Pandas 1.3.2. This mostly includes depreciating pd.Timedelta and using pd.DateOffset instead. (Pull request [#312](https://github.com/brightwind-dev/brightwind/pull/312)).
+3. Update to work with Pandas 1.3.2. This mostly includes depreciating pd.Timedelta and using pd.DateOffset instead. (Pull request #[312](https://github.com/brightwind-dev/brightwind/pull/312)).
 4. In`Correl` fix issue when duplicate column names are sent to `SpeedSort` (Issue #[304](https://github.com/brightwind-dev/brightwind/issues/304))
 5. Added subplotting functionality to `sector_ratio` and improved user control of plotting (Issue #[309](https://github.com/brightwind-dev/brightwind/issues/309))
 6. Allow `dist()` function to take a pd.DataFrame so user can plot multiple distributions on the same plot. (Issue #[264](https://github.com/brightwind-dev/brightwind/issues/264))
    1. As part of this added subplotting functionality for bar plots
 7. Allow 'freq_table()' function to derive a seasonal adjusted frequency distribution if user sets 'seasonal_adjustment' 
-to true. (Issue # [334](https://github.com/brightwind-dev/brightwind/issues/334))
+to true. (Issue #[334](https://github.com/brightwind-dev/brightwind/issues/334))
    1. As part of this, added 'monthly_coverage_threshold' option for the user to ensure good coverage months.
 8. Update to work with matplotlib 3.5.2 and bug fix for plot_freq_distribution and dist functions (Issue #[315](https://github.com/brightwind-dev/brightwind/issues/315)). 
 9. Update to work with numpy>=1.20.0 when pandas=0.25.3. (Issue #[344](https://github.com/brightwind-dev/brightwind/issues/344)). 
@@ -39,7 +39,7 @@ _line_colors_, _legend_ and _figure_size_. (Issue #[349](https://github.com/brig
 16. Updated `LoadBrightHub` URL and generalised functions used for connecting to BrightHub platform without using `boto3` (Issue #[355](https://github.com/brightwind-dev/brightwind/issues/355)).
 17. Removed hardcoded colours for `Shear.TimeOfDay` plots when `plot_type` is 'step' or 'line' and added a colour map. (Issue #[376](https://github.com/brightwind-dev/brightwind/issues/376)).
 18: Fixed bug for `SpeedSort` where the `sector_predict` function was not interpolating data using two fit lines. (Issue #[377](https://github.com/brightwind-dev/brightwind/issues/377)).
-19: Allow `momm` function to derive a seasonal adjusted mean of monthly mean if user sets `seasonal_adjustment` to true. (Issue # [298](https://github.com/brightwind-dev/brightwind/issues/298))
+19: Allow `momm` function to derive a seasonal adjusted mean of monthly mean if user sets `seasonal_adjustment` to true. (Issue #[298](https://github.com/brightwind-dev/brightwind/issues/298))
 
 
 ## [2.0.0]

--- a/brightwind/analyse/analyse.py
+++ b/brightwind/analyse/analyse.py
@@ -455,8 +455,14 @@ def momm(data, date_from: str = '', date_to: str = '', seasonal_adjustment=False
 
     for col in sliced_data.columns:
 
-        # derive monthly coverage
-        monthly_coverage = coverage(sliced_data[col])
+        # Derive monthly coverage
+        # Check if sliced_data resolution is more than the monthly period, if it is the case then the monthly coverage
+        # can not be derived and the data_resolution needs to be given as input to the coverage function.
+        if sliced_data[col].index[0] + tf._freq_str_to_dateoffset('1M') < \
+                sliced_data[col].index[0] + tf._get_data_resolution(sliced_data[col].index):
+            monthly_coverage = coverage(sliced_data[col], period='1M', data_resolution=pd.DateOffset(months=1))
+        else:
+            monthly_coverage = coverage(sliced_data[col], period='1M')
 
         var_series, text_msg = _filter_out_months_based_on_coverage_threshold(sliced_data[col], monthly_coverage,
                                                                               coverage_threshold,

--- a/brightwind/analyse/analyse.py
+++ b/brightwind/analyse/analyse.py
@@ -380,9 +380,9 @@ def _mean_of_monthly_means_seasonal_adjusted(var_series, coverage_threshold=0.8)
 
         results.update({month: var_series_month.mean()})
 
-    average_result = (pd.Series(results) * pd.Series(number_days_month) / sum(
+    result = (pd.Series(results) * pd.Series(number_days_month) / sum(
         number_days_month.values())).sum(skipna=True)
-    return average_result
+    return result
 
 
 def momm(data, date_from: str = '', date_to: str = '', seasonal_adjustment=False, coverage_threshold=0.8):

--- a/brightwind/analyse/analyse.py
+++ b/brightwind/analyse/analyse.py
@@ -387,23 +387,24 @@ def _mean_of_monthly_means_seasonal_adjusted(var_series, coverage_threshold=0.8)
 
 def momm(data, date_from: str = '', date_to: str = '', seasonal_adjustment=False, coverage_threshold=0.8):
     """
-    Calculates and returns the mean of monthy mean speed. Accepts a DataFrame with timestamps as index column and
-    another column with wind-speed. You can also specify date_from and date_to to calculate the mean of monthly
+    Calculates and returns the mean of monthly mean speed. This accepts a DataFrame with timestamps as index column and
+    another column with wind speed. You can also specify date_from and date_to to calculate the mean of monthly
     mean speed for only that period.
 
     If 'seasonal_adjustment' input is set to True then the mean of monthly mean value is seasonally adjusted.
-    NOTE; that if the input datasets ('data') don't have data for each calendar month then the seasonal adjustment
-    is not derived and the function will raise an error.
 
     The seasonal adjusted mean of monthly mean is derived as for method below:
         1) calculate monthly coverage
         2) filter out any months with coverage lower than the input 'coverage_threshold'
-        3) derive the monthly mean for each calendar month (i.e. all January)
+        3) derive the monthly mean for each calendar month (i.e. all Januaries)
         4) weighted average each monthly mean value based on the number of days in each month
            (i.e. 31 days for January) - number of days for February are derived as average of actual days for the year
-           of the dataset. This to take into account leap years.
+           of the dataset. This is to take into account leap years.
 
-    :param data:                Pandas DataFrame or Series with timestamp as index and a column with wind-speed
+    NOTE; that if the input datasets ('data') don't have data for each calendar month then the seasonal adjustment
+    is not derived and the function will raise an error.
+
+    :param data:                Pandas DataFrame or Series with timestamp as index and a column with wind speed
     :type data:                 pd.DataFrame or pd.Series
     :param date_from:           Start date as string in format YYYY-MM-DD
     :type:                      str
@@ -412,9 +413,9 @@ def momm(data, date_from: str = '', date_to: str = '', seasonal_adjustment=False
     :param seasonal_adjustment: Optional, False by default. If True, returns the mean of monthly mean seasonal
                                 adjusted
     :type seasonal_adjustment:  bool
-    :param coverage_threshold:  In this case monthly coverage threshold. It is used only if seasonal_adjustment=True.
-                                Coverage is defined as the ratio of the number of data points present in the month and
-                                the maximum number of data points that a month should have.
+    :param coverage_threshold:  In this case this is a coverage threshold applied to a month. It is used only if
+                                seasonal_adjustment=True. Coverage is defined as the ratio of the number of data points
+                                present in the month and the maximum number of data points that a month should have.
                                 Example, for 10 minute data for June, the maximum number of data points is
                                 43,200. But if the number if data points available is only 30,000 the coverage is
                                 0.69. A coverage_threshold value of 0.8 will filter out any months with a coverage less
@@ -445,7 +446,7 @@ def momm(data, date_from: str = '', date_to: str = '', seasonal_adjustment=False
         momm_data = data.copy()
     sliced_data = utils.slice_data(momm_data, date_from, date_to)
     if seasonal_adjustment:
-        output = pd.DataFrame([np.nan * np.ones(len(momm_data.columns))], columns=momm_data.columns,index=['MOMM'])
+        output = pd.DataFrame([np.nan * np.ones(len(momm_data.columns))], columns=momm_data.columns, index=['MOMM'])
         for col in momm_data.columns:
             output[col] = _mean_of_monthly_means_seasonal_adjusted(sliced_data[col],
                                                                    coverage_threshold=coverage_threshold)

--- a/brightwind/analyse/analyse.py
+++ b/brightwind/analyse/analyse.py
@@ -437,6 +437,9 @@ def momm(data, date_from: str = '', date_to: str = '', seasonal_adjustment=False
         # Derive mean of monthly mean seasonal adjusted and imposing coverage_threshold
         bw.momm(data[['Spd40mN','Spd40mS']], seasonal_adjustment=True, coverage_threshold=0.7)
 
+        # Derive mean of monthly mean seasonal adjusted and set coverage_threshold to 0 to not filter out data.
+        bw.momm(data[['Spd40mN','Spd40mS']], seasonal_adjustment=True, coverage_threshold=0)
+
     """
     if isinstance(data, pd.Series):
         momm_data = data.to_frame()

--- a/brightwind/analyse/analyse.py
+++ b/brightwind/analyse/analyse.py
@@ -425,7 +425,7 @@ def momm(data, date_from: str = '', date_to: str = '', seasonal_adjustment=False
         import brightwind as bw
         data = bw.load_csv(bw.demo_datasets.demo_data)
 
-        # Derive mean of monthly mean with standard method
+        # Derive mean of monthly mean with standard method and not filtering out data based on monthly coverage.
         bw.momm(data[['Spd40mN','Spd40mS']])
 
         # Derive mean of monthly mean with standard method and imposing coverage_threshold

--- a/brightwind/analyse/analyse.py
+++ b/brightwind/analyse/analyse.py
@@ -387,7 +387,8 @@ def momm(data, date_from: str = '', date_to: str = '', seasonal_adjustment=False
 
     The seasonal adjusted mean of monthly mean is derived as for method below:
         1) calculate monthly coverage
-        2) filter out any months with coverage lower than the input 'coverage_threshold'
+        2) filter out any months with coverage lower than the input 'coverage_threshold' (a 'coverage_threshold' is
+           required)
         3) derive the monthly mean for each calendar month (i.e. all Januaries)
         4) weighted average each monthly mean value based on the number of days in each month
            (i.e. 31 days for January) - number of days for February are derived as average of actual days for the year
@@ -402,21 +403,19 @@ def momm(data, date_from: str = '', date_to: str = '', seasonal_adjustment=False
     :type:                      str
     :param date_to:             End date as string in format YYYY-MM-DD
     :type:                      str
-    :param seasonal_adjustment: Optional, False by default. If True, returns the mean of monthly mean seasonal
+    :param seasonal_adjustment: Optional, False by default. If True, returns the mean of monthly mean seasonally
                                 adjusted
     :type seasonal_adjustment:  bool
-    :param coverage_threshold:  In this case this is a coverage threshold applied to a month. Coverage is defined as the
+    :param coverage_threshold:  In this case, coverage threshold is applied to a month. Coverage is defined as the
                                 ratio of the number of data points present in the month and the maximum number of data
                                 points that a month should have. Example, for 10 minute data for June, the maximum
                                 number of data points is 43,200. But if the number if data points available is only
                                 30,000 the coverage is 0.69. A coverage_threshold value of 0.8 will filter out any
                                 months with a coverage less than this. Coverage_threshold should be a value
-                                between 0 and 1. If it is 0 data is not filtered. If it is None data is not filtered
-                                only if seasonal_adjustment is False.
-                                Default value is None.
-                                ** NOTE that if seasonal_adjustment is True and coverage_threshold is None then
-                                the default threshold used is 0.8. If you don't want to apply any coverage
-                                threshold when seasonal_adjustment is True then set coverage_threshold to 0. **
+                                between 0 and 1. If it is 0, data is not filtered. If it is None, data is also not
+                                filtered, except for when the seasonal_adjustment is True. If seasonal_adjustment is
+                                True, then set coverage_threshold to 0 to not filter out data.
+                                Default value is None, except when 'seasonal_adjustment'=True when it is 0.8.
     :type coverage_threshold:   int, float or None
     :returns:                   Long term reference speed
     :rtype:                     panda.Dataframe

--- a/tests/test_analyse.py
+++ b/tests/test_analyse.py
@@ -39,9 +39,24 @@ def test_momm():
     momm_standard = bw.momm(DATA[['Spd40mN', 'Spd40mS']], date_from='2016-06-01', date_to='2017-05-31')
     assert round(momm_standard.T['Spd40mS'].values[0], 6) == 6.684251
 
-    # Derive mean of monthly mean seasonal adjusted and imposing coverage_threshold
+    # Derive mean of monthly mean with standard method only using a certain period and imposing coverage_threshold
+    # equal to 0.7
+    momm_standard = bw.momm(DATA[['Spd40mN', 'Spd40mS']], date_from='2016-05-01', date_to='2017-05-31',
+                            coverage_threshold=0.7)
+    assert round(momm_standard.T['Spd40mS'].values[0], 6) == 6.684251
+
+    # Derive mean of monthly mean seasonal adjusted and imposing coverage_threshold equal to 0.7
     momm_seas_adj = bw.momm(DATA[['Spd40mN', 'Spd40mS']], seasonal_adjustment=True, coverage_threshold=0.7)
     assert round(momm_seas_adj.T['Spd40mN'].values[0], 6) == 6.749667
+
+    # Derive mean of monthly mean seasonal adjusted and imposing coverage_threshold equal to zero
+    momm_seas_adj = bw.momm(DATA[['Spd40mN', 'Spd40mS']], seasonal_adjustment=True, coverage_threshold=0)
+    assert round(momm_seas_adj.T['Spd40mN'].values[0], 6) == 6.797647
+
+    # Derive mean of monthly mean seasonal adjusted and imposing coverage_threshold equal to None
+    momm_seas_adj = bw.momm(DATA[['Spd40mN', 'Spd40mS']], seasonal_adjustment=True, coverage_threshold=None)
+    momm_seas_adj1 = bw.momm(DATA[['Spd40mN', 'Spd40mS']], seasonal_adjustment=True, coverage_threshold=0.8)
+    assert round(momm_seas_adj.T['Spd40mS'].values[0], 6) == round(momm_seas_adj1.T['Spd40mS'].values[0], 6)
 
     # Derive mean of monthly mean seasonal adjusted with months of zero coverage
     data_test = DATA.drop(DATA.loc[str(DATA.index[0].year) + '-' + str(DATA.index.month.unique()[3])].index)

--- a/tests/test_analyse.py
+++ b/tests/test_analyse.py
@@ -30,6 +30,25 @@ def test_monthly_means():
                                      "For example, hourly data should not be averaged to 10 minute data."
 
 
+def test_momm():
+    # Derive mean of monthly mean with standard method
+    momm_standard = bw.momm(DATA[['Spd40mN', 'Spd40mS']])
+    assert round(momm_standard.T['Spd40mN'].values[0], 6) == 6.802488
+
+    # Derive mean of monthly mean with standard method only using a certain period
+    momm_standard = bw.momm(DATA[['Spd40mN', 'Spd40mS']], date_from='2016-06-01', date_to='2017-05-31')
+    assert round(momm_standard.T['Spd40mS'].values[0], 6) == 6.684251
+
+    # Derive mean of monthly mean seasonal adjusted and imposing coverage_threshold
+    momm_seas_adj = bw.momm(DATA[['Spd40mN', 'Spd40mS']], seasonal_adjustment=True, coverage_threshold=0.7)
+    assert round(momm_seas_adj.T['Spd40mN'].values[0], 6) == 6.749667
+
+    # Derive mean of monthly mean seasonal adjusted with months of zero coverage
+    data_test = DATA.drop(DATA.loc[str(DATA.index[0].year) + '-' + str(DATA.index.month.unique()[3])].index)
+    momm_seas_adj = bw.momm(data_test[['Spd40mN', 'Spd40mS']], seasonal_adjustment=True, coverage_threshold=0.7)
+    assert round(momm_seas_adj.T['Spd40mS'].values[0], 6) == 6.864868
+
+
 def test_sector_ratio():
     bw.sector_ratio(DATA['Spd80mN'], DATA['Spd80mS'], DATA['Dir78mS'], sectors=72, boom_dir_1=0,
                     boom_dir_2=180, return_data=True)
@@ -44,8 +63,8 @@ def test_sector_ratio():
                     DATA[['Dir78mS', 'Dir58mS', 'Dir38mS']], boom_dir_1=0, boom_dir_2=180,
                     figure_size=(25,25))
     bw.sector_ratio(DATA[['Spd80mN', 'Spd60mN', 'Spd40mN']], DATA[['Spd80mS', 'Spd60mS', 'Spd40mS']],
-                 DATA[['Dir78mS', 'Dir58mS', 'Dir38mS']], boom_dir_1=0, boom_dir_2=180, figure_size=(25, 25),
-                 return_data=True)
+                    DATA[['Dir78mS', 'Dir58mS', 'Dir38mS']], boom_dir_1=0, boom_dir_2=180, figure_size=(25, 25),
+                    return_data=True)
     bw.sector_ratio(DATA['Spd80mN'], DATA['Spd80mS'], DATA['Dir78mS'], boom_dir_1=0, boom_dir_2=180, return_data=True)
     bw.sector_ratio(DATA[['Spd80mN', 'Spd60mN']], DATA[['Spd80mS', 'Spd60mS']],
                     DATA[['Dir78mS', 'Dir58mS']], boom_dir_1=[0, 350], boom_dir_2=[180, 170], figure_size=(25, 25))


### PR DESCRIPTION
1.  Added option to `momm` function to derive the seasonal adjusted mean of monthly mean speed if input `seasonal_adjustment` is True. 
2. added tests for `momm`

The seasonal adjusted mean of monthly mean is derived as for method below:
        1) calculate monthly coverage
        2) filter out any months with coverage lower than the input 'coverage_threshold'
        3) derive the monthly mean for each calendar month (i.e. all January)
        4) weighted average each monthly mean value based on the number of days in each month
           (i.e. 31 days for January) - number of days for February are derived as average of actual days for the year
           of the dataset. This to take into account leap years.