### PR TITLE
[Iss381] Fixed `_ColorPalette` to automatically update colours dependent from main colours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ _line_colors_, _legend_ and _figure_size_. (Issue #[349](https://github.com/brig
 16. Updated `LoadBrightHub` URL and generalised functions used for connecting to BrightHub platform without using `boto3` (Issue #[355](https://github.com/brightwind-dev/brightwind/issues/355)).
 17. Removed hardcoded colours for `Shear.TimeOfDay` plots when `plot_type` is 'step' or 'line' and added a colour map. (Issue #[376](https://github.com/brightwind-dev/brightwind/issues/376)).
 18: Fixed bug for `SpeedSort` where the `sector_predict` function was not interpolating data using two fit lines. (Issue #[377](https://github.com/brightwind-dev/brightwind/issues/377)).
+19. Fixed `_ColorPalette` to automatically update color_list, color_map, color_map_cyclical and adjusted lightness color variables when main colors (primary, secondary etc.) are changed. (Issue #[381](https://github.com/brightwind-dev/brightwind/issues/381)).
 
 
 ## [2.0.0]

--- a/brightwind/analyse/plot.py
+++ b/brightwind/analyse/plot.py
@@ -1218,11 +1218,14 @@ def _bar_subplot(data, x_label=None, y_label=None, min_bar_axis_limit=None, max_
         # The offset in x direction of that bar
         x_offset = (i - n_bars / 2) * bar_width + bar_width / 2
         r, g, b = tuple(255 * np.array(mpl.colors.to_rgb(bar_color)))  # hex to rgb format
+        hue, lightness, saturation = rgb2hls(r / 255, g / 255, b / 255)
+        lightness_factor = max(min(lightness * 1.8, 1.0), 0.0)
 
         for data_bar, data_bin in zip(data[name], data_bins):
             if vertical_bars:
                 ax.imshow(np.array([[mpl.colors.to_rgb(bar_color)],
-                                    [mpl.colors.to_rgb(_adjust_color_lightness(bar_color, lightness_factor=0.8))]]),
+                                    [mpl.colors.to_rgb(_adjust_color_lightness(bar_color,
+                                                                               lightness_factor=lightness_factor))]]),
                           interpolation='gaussian', extent=(data_bin + x_offset - bar_width / 2,
                                                             data_bin + x_offset + bar_width / 2, 0,
                                                             data_bar),
@@ -1231,7 +1234,8 @@ def _bar_subplot(data, x_label=None, y_label=None, min_bar_axis_limit=None, max_
                              edgecolor=bar_color, linewidth=line_width, fill=False,
                              zorder=1)#5
             else:
-                cmp = _create_colormap(mpl.colors.to_rgb(_adjust_color_lightness(bar_color, lightness_factor=0.8)),
+                cmp = _create_colormap(mpl.colors.to_rgb(_adjust_color_lightness(bar_color,
+                                                                                 lightness_factor=lightness_factor)),
                                        mpl.colors.to_rgb(bar_color))
                 ax.imshow(_gradient_image(direction=1, cmap_range=(0, 1)), cmap=cmp,
                           interpolation='gaussian',

--- a/brightwind/analyse/plot.py
+++ b/brightwind/analyse/plot.py
@@ -41,15 +41,80 @@ class _ColorPalette:
 
     def __init__(self):
         """
-        Color palette to be used for plotting graphs and tables. Colors can be reset by using
+        Color palette to be used for plotting graphs and tables. This Class generates also color_list, color_map,
+        color_map_cyclical and some adjusted lightness color variables that are created from the main colors defined
+        below and used by several brightwind functions.
 
+        1) The main colors used to define the color palette are:
+            self.primary = '#9CC537'        # slightly darker than YellowGreen #9acd32, rgb(156/255, 197/255, 55/255)
+            self.secondary = '#2E3743'      # asphalt, rgb(46/255, 55/255, 67/255)
+            self.tertiary = '#9B2B2C'       # red'ish, rgb(155/255, 43/255, 44/255)
+            self.fourth = '#E57925'         # orange'ish, rgb(229/255, 121/255, 37/255)
+            self.fifth = '#ffc008'          # yellow'ish, rgb(255/255, 192/255, 8/255)
+            self.sixth = '#AB8D60'          # brown'ish, rgb(171/255, 141/255, 96/255)
+            self.seventh = '#A4D29F'        # brown'ish, rgb(171/255, 141/255, 96/255)
+            self.eighth = '#01958a'         # grayish lime green, rgb(164/255, 210/255, 156/255)
+            self.ninth = '#3D636F'          # blue grey, rgb(61/255, 99/255, 111/255)
+            self.tenth = '#A49E9D'          # dark grayish red, rgb(164/255, 158/255, 157/255)
+            self.eleventh = '#DA9BA6'       # very soft red, rgb(218/255, 155/255, 166/255)
+
+        2) The adjusted lightness color variables derived from the main colors above are as below.
+           Gradient goes from 0% (darkest) to 100% (lightest).
+           See https://www.w3schools.com/colors/colors_picker.asp for more info.
+
+            self.primary_10  # 10% lightness of primary
+            self.primary_35  # lightness of primary
+            self.primary_80  # lightness of primary
+            self.primary_90  # 90% lightness of primary
+            self.primary_95  # 95% lightness of primary
+            self.tenth_40    # 40% lightness of tenth
+
+        3) The color sequence used for defining the color_list variable is as below:
+            color_list = [self.primary, self.secondary, self.tertiary, self.fourth, self.fifth, self.sixth,
+                          self.seventh, self.eighth, self.ninth, self.tenth, self.eleventh, self.primary_35]
+
+        4) The color sequence used for defining the color_map variable is as below. This variable is a
+           color map having a linear color pattern from the first color to the last color of the _color_map_colors list.
+            self._color_map_colors = [self.primary_95,  # lightest primary
+                                      self.primary,     # primary
+                                      self.primary_10]  # darkest primary
+
+        5) The color sequence used for defining the color_map_cyclical variable is as below. This variable is a
+           color map having a cyclical color pattern from/to the first color of the _color_map_cyclical_colors.
+            self._color_map_cyclical_colors = [self.secondary, self.fifth, self.primary, self.tertiary, self.secondary]
+
+        **Example usage**
         ::
             import brightwind as bw
+
+            # Main colors can be reset by using the code below for each color of the defined color palette. When doing
+            # this the linked color_list, color_map, color_map_cyclical and adjusted lightness color variables are
+            # automatically updated as a consequence.
+
             bw.analyse.plot.COLOR_PALETTE.primary = '#3366CC'
 
-        Color are called 'primary', secondary', 'tertiary', etc. Lighter and darker shades of primary are called
-        'primary_10' for 10% of primary. Gradient goes from 0% (darkest) to 100% (lightest). See
-        https://www.w3schools.com/colors/colors_picker.asp for more info.
+            # The adjusted lightness colors can also be reset by using the example code below:
+
+            bw.analyse.plot.COLOR_PALETTE.primary_10 = '#0a1429'
+
+            # The colors used for defining the color_map can also be reset by using the example code below:
+
+            bw.analyse.plot.COLOR_PALETTE.set_color_map_colors = ['#ccfffc',   # lightest primary
+                                                                  '#00b4aa',   # vert-dark
+                                                                  '#008079']   # darkest primary
+
+            # The colors used for defining the color_map_cyclical can also be reset by using the example code below:
+
+            bw.analyse.plot.COLOR_PALETTE.set_color_map_cyclical = ['#ccfffc',   # lightest primary
+                                                                    '#00b4aa',   # vert-dark
+                                                                    '#008079',   # darkest primary
+                                                                    '#ccfffc']   # lightest primary
+
+            # The hex color value corresponding to an input color adjusted by a percentage lightness (e.g 0.5 %)
+            # can be derived as below:
+
+            bw.analyse.plot.COLOR_PALETTE._adjust_color_lightness('#171a28', 0.5)
+
         """
         self.primary = '#9CC537'        # slightly darker than YellowGreen #9acd32, rgb(156/255, 197/255, 55/255)
         self.secondary = '#2E3743'      # asphalt, rgb(46/255, 55/255, 67/255)
@@ -177,6 +242,7 @@ def _colormap_to_colorscale(cmap, n_colors):
     Function that transforms a matplotlib colormap to a list of colors
     """
     return [to_hex(cmap(k*1/(n_colors-1))) for k in range(n_colors)]
+
 
 def plot_monthly_means(data, coverage=None, ylbl=''):
     fig = plt.figure(figsize=(15, 8))

--- a/brightwind/analyse/plot.py
+++ b/brightwind/analyse/plot.py
@@ -51,23 +51,23 @@ class _ColorPalette:
         'primary_10' for 10% of primary. Gradient goes from 0% (darkest) to 100% (lightest). See
         https://www.w3schools.com/colors/colors_picker.asp for more info.
         """
-        self.primary = '#9CC537'        # slightly darker than YellowGreen #9acd32, rgb[156/255, 197/255, 55/255]
-        self.secondary = '#2E3743'      # asphalt, rgb[46/255, 55/255, 67/255]
-        self.tertiary = '#9B2B2C'       # red'ish, rgb(155, 43, 44)
-        self.fourth = '#E57925'         # orange'ish, rgb(229, 121, 37)
-        self.fifth = '#ffc008'          # yellow'ish, rgb(255, 192, 8)
-        self.sixth = '#AB8D60'
-        self.seventh = '#A4D29F'
-        self.eighth = '#01958a'
-        self.ninth = '#3D636F'          # blue grey
-        self.tenth = '#A49E9D'
-        self.eleventh = '#DA9BA6'
-        self.primary_10 = '#1F290A'     # darkest green, 10% of primary
-        self.primary_35 = '#6C9023'     # dark green, 35% of primary
-        self.primary_80 = '#D7EBAD'     # light green, 80% of primary
-        self.primary_90 = '#ebf5d6'     # light green, 90% of primary
-        self.primary_95 = '#F5FAEA'     # lightest green, 95% of primary
-        self.secondary_70 = '#6d737b'   # light asphalt
+        self.primary = '#9CC537'        # slightly darker than YellowGreen #9acd32, rgb(156/255, 197/255, 55/255)
+        self.secondary = '#2E3743'      # asphalt, rgb(46/255, 55/255, 67/255)
+        self.tertiary = '#9B2B2C'       # red'ish, rgb(155/255, 43/255, 44/255)
+        self.fourth = '#E57925'         # orange'ish, rgb(229/255, 121/255, 37/255)
+        self.fifth = '#ffc008'          # yellow'ish, rgb(255/255, 192/255, 8/255)
+        self.sixth = '#AB8D60'          # brown'ish, rgb(171/255, 141/255, 96/255)
+        self.seventh = '#A4D29F'        # brown'ish, rgb(171/255, 141/255, 96/255)
+        self.eighth = '#01958a'         # grayish lime green, rgb(164/255, 210/255, 156/255)
+        self.ninth = '#3D636F'          # blue grey, rgb(61/255, 99/255, 111/255)
+        self.tenth = '#A49E9D'          # dark grayish red, rgb(164/255, 158/255, 157/255)
+        self.eleventh = '#DA9BA6'       # very soft red, rgb(218/255, 155/255, 166/255)
+        self.primary_10 = '#1F290A'     # darkest green, 10% lightness of primary
+        self.primary_35 = '#6C9023'     # dark green, 35% lightness of primary
+        self.primary_80 = '#D7EBAD'     # light green, 80% lightness of primary
+        self.primary_90 = '#ebf5d6'     # light green, 90% lightness of primary
+        self.primary_95 = '#F5FAEA'     # lightest green, 95% lightness of primary
+        self.tenth_40 = '#6a6362'       # darker dark grayish red, 40% lightness of tenth
 
         _col_map_colors = [self.primary_95,  # lightest primary
                            self.primary,     # primary
@@ -602,7 +602,7 @@ def _scatter_subplot(x, y, trendline_y=None, trendline_x=None, line_of_slope_1=F
         low_y, high_y = ax.get_ylim()
         low = max(low_x, low_y)
         high = min(high_x, high_y)
-        ax.plot([low, high], [low, high], color=COLOR_PALETTE.secondary_70, label='1:1 line')
+        ax.plot([low, high], [low, high], color=COLOR_PALETTE.tenth_40, label='1:1 line')
 
     ax.set_xlabel(x_label)
     ax.set_ylabel(y_label)

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -156,3 +156,11 @@ def test_adjust_color_lightness():
     hue1, lightness1, saturation1 = rgb2hls(r / 255, g / 255, b / 255)
     assert (int(hue * 100) == int(hue1 * 100)) and (int(saturation * 100) == int(saturation1 * 100)) and \
            (lightness1 == 0.1)
+
+    assert bw.analyse.plot._adjust_color_lightness(input_color, 0.1) == "#20280b"  # darkest green, 10% of primary
+    assert bw.analyse.plot._adjust_color_lightness(input_color, 0.35) == "#6e8c27"  # dark green, 35% of primary
+    assert bw.analyse.plot._adjust_color_lightness(input_color, 0.8) == "#d8e9af"  # light green, 80% of primary
+    assert bw.analyse.plot._adjust_color_lightness(input_color, 0.9) == "#ecf4d7"  # light green, 90% of primary
+    assert bw.analyse.plot._adjust_color_lightness(input_color, 0.95) == "#f5f9eb"  # lightest green, 95% of primary
+
+

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,5 +1,6 @@
 import pytest
 import brightwind as bw
+from brightwind.analyse import plot as bw_plt
 import matplotlib.pyplot as plt
 import pandas as pd
 import numpy as np
@@ -152,15 +153,21 @@ def test_adjust_color_lightness():
     input_color = '#9CC537'
     r, g, b = tuple(255 * np.array(mpl.colors.to_rgb(input_color)))
     hue, lightness, saturation = rgb2hls(r / 255, g / 255, b / 255)
-    r, g, b = tuple(255 * np.array(mpl.colors.to_rgb(bw.analyse.plot._adjust_color_lightness(input_color, 0.1))))
+    r, g, b = tuple(255 * np.array(mpl.colors.to_rgb(bw_plt.COLOR_PALETTE._adjust_color_lightness(
+        input_color, 0.1))))
     hue1, lightness1, saturation1 = rgb2hls(r / 255, g / 255, b / 255)
     assert (int(hue * 100) == int(hue1 * 100)) and (int(saturation * 100) == int(saturation1 * 100)) and \
            (lightness1 == 0.1)
 
-    assert bw.analyse.plot._adjust_color_lightness(input_color, 0.1) == "#20280b"  # darkest green, 10% of primary
-    assert bw.analyse.plot._adjust_color_lightness(input_color, 0.35) == "#6e8c27"  # dark green, 35% of primary
-    assert bw.analyse.plot._adjust_color_lightness(input_color, 0.8) == "#d8e9af"  # light green, 80% of primary
-    assert bw.analyse.plot._adjust_color_lightness(input_color, 0.9) == "#ecf4d7"  # light green, 90% of primary
-    assert bw.analyse.plot._adjust_color_lightness(input_color, 0.95) == "#f5f9eb"  # lightest green, 95% of primary
+    assert bw_plt.COLOR_PALETTE._adjust_color_lightness(
+        input_color, 0.1) == "#20280b"  # darkest green, 10% of primary
+    assert bw_plt.COLOR_PALETTE._adjust_color_lightness(
+        input_color, 0.35) == "#6e8c27"  # dark green, 35% of primary
+    assert bw_plt.COLOR_PALETTE._adjust_color_lightness(
+        input_color, 0.8) == "#d8e9af"  # light green, 80% of primary
+    assert bw_plt.COLOR_PALETTE._adjust_color_lightness(
+        input_color, 0.9) == "#ecf4d7"  # light green, 90% of primary
+    assert bw_plt.COLOR_PALETTE._adjust_color_lightness(
+        input_color, 0.95) == "#f5f9eb"  # lightest green, 95% of primary
 
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -5,6 +5,8 @@ import pandas as pd
 import numpy as np
 from matplotlib.ticker import PercentFormatter
 from matplotlib.dates import DateFormatter
+import matplotlib as mpl
+from colormap import rgb2hex, rgb2hls, hls2rgb
 
 DATA = bw.load_csv(bw.demo_datasets.demo_data)
 DATA = bw.apply_cleaning(DATA, bw.demo_datasets.demo_cleaning_file)
@@ -144,3 +146,13 @@ def test_plot_freq_distribution():
                                            max_y_value=None, x_tick_labels=None, x_label=None,
                                            y_label='count', total_width=1, legend=True)
     assert True
+
+
+def test_adjust_color_lightness():
+    input_color = '#9CC537'
+    r, g, b = tuple(255 * np.array(mpl.colors.to_rgb(input_color)))
+    hue, lightness, saturation = rgb2hls(r / 255, g / 255, b / 255)
+    r, g, b = tuple(255 * np.array(mpl.colors.to_rgb(bw.analyse.plot._adjust_color_lightness(input_color, 0.1))))
+    hue1, lightness1, saturation1 = rgb2hls(r / 255, g / 255, b / 255)
+    assert (int(hue * 100) == int(hue1 * 100)) and (int(saturation * 100) == int(saturation1 * 100)) and \
+           (lightness1 == 0.1)

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -171,3 +171,30 @@ def test_adjust_color_lightness():
         input_color, 0.95) == "#f5f9eb"  # lightest green, 95% of primary
 
 
+def test_ColorPalette():
+    color_palette = bw.analyse.plot.COLOR_PALETTE
+    assert color_palette.color_list == ['#9CC537', '#2E3743', '#9B2B2C', '#E57925', '#ffc008', '#AB8D60', '#A4D29F',
+                                        '#01958a', '#3D636F', '#A49E9D', '#DA9BA6', '#6e8c27']
+
+    color_palette.primary = '#3366CC'
+    assert bw.analyse.plot.COLOR_PALETTE.primary == '#3366CC'
+    assert color_palette.color_list[0] == bw.analyse.plot.COLOR_PALETTE.primary
+    assert bw.analyse.plot.COLOR_PALETTE.color_map_colors[1] == color_palette.primary
+
+    color_palette.secondary = '#726e83'
+    assert bw.analyse.plot.COLOR_PALETTE.color_list[1] == '#726e83'
+    assert bw.analyse.plot.COLOR_PALETTE.color_list[2] == '#9B2B2C'
+
+    color_palette.primary_10 = '#0a1429'
+    assert bw.analyse.plot.COLOR_PALETTE.primary_10 == '#0a1429'
+    assert color_palette._color_map_colors[-1] == color_palette.primary_10
+
+    color_palette.set_color_map_colors = ['#ccfffc', '#00b4aa', '#008079']
+    assert bw.analyse.plot.COLOR_PALETTE.set_color_map_colors == ['#ccfffc', '#00b4aa', '#008079']
+
+    color_palette.set_color_map_cyclical = ['#ccfffc', '#00b4aa', '#008079', '#ccfffc']
+    assert bw.analyse.plot.COLOR_PALETTE.set_color_map_cyclical == ['#ccfffc', '#00b4aa', '#008079', '#ccfffc']
+
+
+
+


### PR DESCRIPTION
I have made the following changes to the `_ColorPalette` class:

1.  updated all adjusted lightness color variables (e.g self.primary_10, self.primary_35 etc) to be automatically generated/updated from the main color of the color palette (e.g self.primary), using the `_adjust_color_lightness` function.
2. updated `color_map` variable to be automatically generated/updated from the main color of the color palette (e.g self.primary). If the main color used for defining `color_map` is changed then `color_map` is updated as a consequence.
3. kept option to be able to redefine the input colors used for generating the `color_map`. As for example provided in docstring.
4. updated `color_map_cyclical_colors` variable to be automatically generated/updated from the main color of the color palette (e.g self.secondary). If one of the main colors used for defining `color_map_cyclical_colors` is changed then `color_map_cyclical_colors` is updated as a consequence.
5. kept option to be able to redefine the input colors used for generating the `color_map_cyclical_colors`. As for example provided in docstring.
6. updated `color_list` variable to be automatically generated/updated from the main color of the color palette (e.g self.secondary). If one of the main colors used for defining `color_list` is changed then `color_list` is updated as a consequence.
7. moved `_adjust_color_lightness` function inside `_ColorPalette` class.
8. updated any functions using `_adjust_color_lightness` or other variables of `_ColorPalette` to use the correct reference.
9. added tests for `_ColorPalette` 
10. updated changelog file
