### PR TITLE
[iss #389] fixed issue generating errors with matplotlib version=3.7.1

### DIFF
--- a/brightwind/analyse/plot.py
+++ b/brightwind/analyse/plot.py
@@ -1220,27 +1220,28 @@ def _bar_subplot(data, x_label=None, y_label=None, min_bar_axis_limit=None, max_
         r, g, b = tuple(255 * np.array(mpl.colors.to_rgb(bar_color)))  # hex to rgb format
 
         for data_bar, data_bin in zip(data[name], data_bins):
-            if vertical_bars:
-                ax.imshow(np.array([[mpl.colors.to_rgb(bar_color)],
-                                    [mpl.colors.to_rgb(_adjust_color_lightness(r, g, b, factor=1.8))]]),
-                          interpolation='gaussian', extent=(data_bin + x_offset - bar_width / 2,
-                                                            data_bin + x_offset + bar_width / 2, 0,
-                                                            data_bar),
-                          aspect='auto', zorder=2)#3
-                bar = ax.bar(data_bin + x_offset, data_bar, width=bar_width,
-                             edgecolor=bar_color, linewidth=line_width, fill=False,
-                             zorder=1)#5
-            else:
-                cmp = _create_colormap(mpl.colors.to_rgb(_adjust_color_lightness(r, g, b, factor=1.8)),
-                                       mpl.colors.to_rgb(bar_color))
-                ax.imshow(_gradient_image(direction=1, cmap_range=(0, 1)), cmap=cmp,
-                          interpolation='gaussian',
-                          extent=(0, data_bar, data_bin + x_offset - bar_width / 2,
-                                  data_bin + x_offset + bar_width / 2),
-                          aspect='auto', zorder=2, vmin=0, vmax=1)
-                bar = ax.barh(data_bin + x_offset, data_bar, height=bar_width,
-                              edgecolor=bar_color, linewidth=line_width, fill=False,
-                              zorder=1)#2
+            if not np.isnan(data_bar):
+                if vertical_bars:
+                    ax.imshow(np.array([[mpl.colors.to_rgb(bar_color)],
+                                        [mpl.colors.to_rgb(_adjust_color_lightness(r, g, b, factor=1.8))]]),
+                              interpolation='gaussian', extent=(data_bin + x_offset - bar_width / 2,
+                                                                data_bin + x_offset + bar_width / 2, 0,
+                                                                data_bar),
+                              aspect='auto', zorder=2)#3
+                    bar = ax.bar(data_bin + x_offset, data_bar, width=bar_width,
+                                 edgecolor=bar_color, linewidth=line_width, fill=False,
+                                 zorder=1)#5
+                else:
+                    cmp = _create_colormap(mpl.colors.to_rgb(_adjust_color_lightness(r, g, b, factor=1.8)),
+                                           mpl.colors.to_rgb(bar_color))
+                    ax.imshow(_gradient_image(direction=1, cmap_range=(0, 1)), cmap=cmp,
+                              interpolation='gaussian',
+                              extent=(0, data_bar, data_bin + x_offset - bar_width / 2,
+                                      data_bin + x_offset + bar_width / 2),
+                              aspect='auto', zorder=2, vmin=0, vmax=1)
+                    bar = ax.barh(data_bin + x_offset, data_bar, height=bar_width,
+                                  edgecolor=bar_color, linewidth=line_width, fill=False,
+                                  zorder=1)#2
         # Add a handle to the last drawn bar, which we'll need for the legend
         bar[0].set_color(bar_color)
         bar[0].set_fill(True)


### PR DESCRIPTION
 A very small fix was made in `_bar_subplot` in order to handle minor update in matplotlib version=3.7.1  (not hadling nan or inf values for plot axis limits). This fix was tested with `matplotlib <= 3.7.1, Python <= 3.10.9, numpy <=1.24.1, pandas<=1.5.3` .