### PR TITLE
[Iss386] freq table basic coverage thresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ _line_colors_, _legend_ and _figure_size_. (Issue #[349](https://github.com/brig
 18. Fixed bug for `SpeedSort` where the `sector_predict` function was not interpolating data using two fit lines. (Issue #[377](https://github.com/brightwind-dev/brightwind/issues/377)).
 19. Updated `_ColorPalette` to automatically update color_list, color_map, color_map_cyclical and adjusted lightness color variables when main colors (primary, secondary etc.) are changed. (Issue #[381](https://github.com/brightwind-dev/brightwind/issues/381)).
 19. Allow `momm` function to derive a seasonal adjusted mean of monthly mean, if user sets `seasonal_adjustment` to true, and allow to apply a `coverage_threshold` (Issue #[298](https://github.com/brightwind-dev/brightwind/issues/298))
+20. Allow `freq_tab` function to apply a `coverage_threshold` for both seasonal adjusted and base methods. (Issue #[386](https://github.com/brightwind-dev/brightwind/issues/386))
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ to true. (Issue #[334](https://github.com/brightwind-dev/brightwind/issues/334))
 _line_colors_, _legend_ and _figure_size_. (Issue #[349](https://github.com/brightwind-dev/brightwind/issues/349)).
 11. In `average_data_by_period()` fixed issue when wind direction average is derived for a period equal to the data resolution period 
 (Issue #[319](https://github.com/brightwind-dev/brightwind/issues/319)).
-13. In `freq_tab()` added option to give as input target wind speed we want the mean frequency distribution to have 
+13. In `freq_table` added option to give as input target wind speed we want the mean frequency distribution to have 
 (Issue #[269](https://github.com/brightwind-dev/brightwind/issues/269)).
 12. Fixed bugs for `TI.by_speed` and `TI.by_sector` and added tests. Solved versions issue that were raised from Pandas 1.3.3. (Issue #[317](https://github.com/brightwind-dev/brightwind/issues/317)).
 11. Address errors and warnings generated for `Shear.TimeOfDay` and `Shear` when pandas >=1.0.0 (Issue #[347](https://github.com/brightwind-dev/brightwind/issues/347)).
@@ -41,7 +41,7 @@ _line_colors_, _legend_ and _figure_size_. (Issue #[349](https://github.com/brig
 18. Fixed bug for `SpeedSort` where the `sector_predict` function was not interpolating data using two fit lines. (Issue #[377](https://github.com/brightwind-dev/brightwind/issues/377)).
 19. Updated `_ColorPalette` to automatically update color_list, color_map, color_map_cyclical and adjusted lightness color variables when main colors (primary, secondary etc.) are changed. (Issue #[381](https://github.com/brightwind-dev/brightwind/issues/381)).
 19. Allow `momm` function to derive a seasonal adjusted mean of monthly mean, if user sets `seasonal_adjustment` to true, and allow to apply a `coverage_threshold` (Issue #[298](https://github.com/brightwind-dev/brightwind/issues/298))
-20. Allow `freq_tab` function to apply a `coverage_threshold` for both seasonal adjusted and base methods. (Issue #[386](https://github.com/brightwind-dev/brightwind/issues/386))
+20. Allow `freq_table` function to apply a `coverage_threshold` for both seasonal adjusted and base methods. (Issue #[386](https://github.com/brightwind-dev/brightwind/issues/386))
 
 
 

--- a/brightwind/analyse/analyse.py
+++ b/brightwind/analyse/analyse.py
@@ -294,7 +294,7 @@ def _filter_out_months_based_on_coverage_threshold(var_series, monthly_coverage,
 
         text_months_fail = ", ".join(map(str, list(months_fail_coverage.index.strftime('%b-%Y'))))
         text_warning = 'These months are filtered out for deriving the {}{}.'.format(text_seas_adj,
-                                                                                      analysis_type)
+                                                                                     analysis_type)
     else:
         text_months_fail = ''
         text_warning = ''
@@ -332,7 +332,8 @@ def _filter_out_months_based_on_coverage_threshold(var_series, monthly_coverage,
                        ' {}'.format(variable_name, text_months_fail, coverage_threshold, text_warning)
 
     # check that var_series_filtered dataset has data for all calendar months
-    if len(var_series_filtered.index.month.unique()) < 12 and seasonal_adjustment:
+    if len(monthly_coverage[monthly_coverage >= coverage_threshold].dropna().index.month.unique()) < 12 \
+            and seasonal_adjustment:
         raise ValueError('Note{}: The input series filtered by the input monthly coverage threshold do not cover all '
                          'calendar months. The seasonal adjusted {} '
                          'cannot be derived.'.format(variable_name, analysis_type))
@@ -1207,10 +1208,11 @@ def freq_table(var_series, direction_series, var_bin_array=np.arange(-0.5, 41, 1
 
     # derive monthly coverage considering var_series, direction_series inputs
     monthly_coverage = coverage(pd.concat([var_series.rename('var_data'), direction_series],
-                                          axis=1).dropna())['var_data_Coverage'].combine(
-        coverage(var_series), min).replace(np.nan, 0.0)
+                                          axis=1)).min(axis=1).replace(np.nan, 0.0)
 
-    var_series, text_msg_out = _filter_out_months_based_on_coverage_threshold(var_series, monthly_coverage,
+    var_series, text_msg_out = _filter_out_months_based_on_coverage_threshold(pd.concat([var_series, direction_series],
+                                                                                        axis=1)[var_series.name],
+                                                                              monthly_coverage,
                                                                               coverage_threshold,
                                                                               analysis_type='frequency table',
                                                                               seasonal_adjustment=seasonal_adjustment)

--- a/brightwind/analyse/analyse.py
+++ b/brightwind/analyse/analyse.py
@@ -1153,9 +1153,20 @@ def freq_table(var_series, direction_series, var_bin_array=np.arange(-0.5, 41, 1
         display(rose)
         display(freq_table)
 
+        # To get the plot and the freq table imposing a coverage_threshold of 0.5.
+        rose, freq_table = bw.freq_table(data.Spd40mN, data.Dir38mS, return_data=True, coverage_threshold=0.5)
+        display(rose)
+        display(freq_table)
+
         # Apply seasonal adjustment and coverage threshold of 70%
         rose, freq_table = bw.freq_table(data.Spd40mN, data.Dir38mS, return_data=True, seasonal_adjustment=True,
                                          coverage_threshold=0.7)
+        display(rose)
+        display(freq_table)
+
+        # Apply seasonal adjustment and set coverage_threshold to 0 to not filter out data.
+        rose, freq_table = bw.freq_table(data.Spd40mN, data.Dir38mS, return_data=True, seasonal_adjustment=True,
+                                         coverage_threshold=0)
         display(rose)
         display(freq_table)
 
@@ -1252,7 +1263,6 @@ def freq_table(var_series, direction_series, var_bin_array=np.arange(-0.5, 41, 1
                                                     sectors=sectors, direction_bin_array=direction_bin_array,
                                                     direction_bin_labels=None, aggregation_method=agg_method
                                                     ).replace(np.nan, 0.0)
-            text_msg_out = None
 
         if target_freq_table_mean is None:
             k = -1

--- a/brightwind/analyse/analyse.py
+++ b/brightwind/analyse/analyse.py
@@ -235,7 +235,7 @@ def monthly_means(data, return_data=False, return_coverage=False, ylabel='Wind s
     return bw_plt.plot_monthly_means(df, ylbl=ylabel)
 
 
-def _filter_out_months_based_on_coverage_threshold(var_series, coverage_threshold, analysis_type,
+def _filter_out_months_based_on_coverage_threshold(var_series, monthly_coverage, coverage_threshold, analysis_type,
                                                    seasonal_adjustment):
     """
     Filter out var_series data periods when coverage is lower than coverage_threshold and return a text message
@@ -243,6 +243,8 @@ def _filter_out_months_based_on_coverage_threshold(var_series, coverage_threshol
 
     :param var_series:              Series of variable whose monthly data are filtered out from.
     :type var_series:               pandas.Series
+    :param monthly_coverage:        Monthly coverage of var_series data derived using brightwind.coverage() function.
+    :type monthly_coverage:         pandas.Dataframe
     :param coverage_threshold:      In this case monthly coverage threshold. Coverage is defined as the ratio of the
                                     number of data points present in the month and the maximum number of data points
                                     that a month should have. Example, for 10 minute data for June, the maximum number
@@ -272,15 +274,6 @@ def _filter_out_months_based_on_coverage_threshold(var_series, coverage_threshol
         text_seas_adj = 'seasonally adjusted '
     else:
         text_seas_adj = ''
-
-    # Derive monthly coverage
-    # Check if var_series data resolution is more than the monthly period, if it is the case then the monthly coverage
-    # can not be derived and the data_resolution needs to be given as input to the coverage function.
-    if var_series.index[0] + tf._freq_str_to_dateoffset('1M') < \
-            var_series.index[0] + tf._get_data_resolution(var_series.index):
-        monthly_coverage = coverage(var_series, period='1M', data_resolution=pd.DateOffset(months=1))
-    else:
-        monthly_coverage = coverage(var_series, period='1M')
 
     # Remove months with coverage threshold lower than the input coverage_threshold.
     if (monthly_coverage < coverage_threshold).sum() > 0:
@@ -464,7 +457,18 @@ def momm(data, date_from: str = '', date_to: str = '', seasonal_adjustment=False
     output = pd.DataFrame([np.nan * np.ones(len(sliced_data.columns))], columns=sliced_data.columns, index=['MOMM'])
 
     for col in sliced_data.columns:
-        var_series, text_msg = _filter_out_months_based_on_coverage_threshold(sliced_data[col], coverage_threshold,
+
+        # Derive monthly coverage
+        # Check if sliced_data resolution is more than the monthly period, if it is the case then the monthly coverage
+        # can not be derived and the data_resolution needs to be given as input to the coverage function.
+        if sliced_data[col].index[0] + tf._freq_str_to_dateoffset('1M') < \
+                sliced_data[col].index[0] + tf._get_data_resolution(sliced_data[col].index):
+            monthly_coverage = coverage(sliced_data[col], period='1M', data_resolution=pd.DateOffset(months=1))
+        else:
+            monthly_coverage = coverage(sliced_data[col], period='1M')
+
+        var_series, text_msg = _filter_out_months_based_on_coverage_threshold(sliced_data[col], monthly_coverage,
+                                                                              coverage_threshold,
                                                                               analysis_type='mean of monthly mean',
                                                                               seasonal_adjustment=seasonal_adjustment)
         if text_msg:

--- a/brightwind/analyse/analyse.py
+++ b/brightwind/analyse/analyse.py
@@ -1066,7 +1066,7 @@ def freq_table(var_series, direction_series, var_bin_array=np.arange(-0.5, 41, 1
     direction are binned.
 
     If 'seasonal_adjustment' input is set to True then the frequency table is seasonally adjusted.
-    NOTE; that if the input datasets ('var_series' or 'direction_series') don't have data for each calendar month
+    NOTE; that if the input datasets ('var_series' or/and 'direction_series') don't have data for each calendar month
     then the seasonal adjustment is not derived and the function will raise an error.
 
     The seasonal adjusted frequency table is derived following the method below:
@@ -1204,7 +1204,6 @@ def freq_table(var_series, direction_series, var_bin_array=np.arange(-0.5, 41, 1
     # Create Dataframe with same coverage for var_series and direction_series to handle inconsistent coverage
     var_series = _convert_df_to_series(var_series).copy()
     direction_series = _convert_df_to_series(direction_series).copy()
-    data_concurrent = pd.concat([var_series, direction_series], axis=1).dropna()
 
     # derive monthly coverage considering var_series, direction_series inputs
     monthly_coverage = coverage(pd.concat([var_series.rename('var_data'), direction_series],
@@ -1216,6 +1215,8 @@ def freq_table(var_series, direction_series, var_bin_array=np.arange(-0.5, 41, 1
                                                                               coverage_threshold,
                                                                               analysis_type='frequency table',
                                                                               seasonal_adjustment=seasonal_adjustment)
+
+    data_concurrent = pd.concat([var_series, direction_series], axis=1).dropna()
 
     # If `target_freq_table_mean` is given as input to function then derive scale factor as ratio of
     # `target_freq_table_mean` and `data_concurrent` means.

--- a/tests/test_analyse.py
+++ b/tests/test_analyse.py
@@ -275,8 +275,8 @@ def test_freq_table():
     assert 'Some months may have very little data coverage' in str(fig_rose.get_default_bbox_extra_artists()[1])
 
     fig_rose, freq_tbl_seas_adj = bw.freq_table(DATA.Spd40mN, DATA.Dir38mS, return_data=True, seasonal_adjustment=True,
-                                                coverage_threshold=0.8, target_freq_table_mean=8.5)
-    assert round(8.5, 3) == round(bw.export.export._calc_mean_speed_of_freq_tab(freq_tbl_seas_adj), 3)
+                                                coverage_threshold=0.8, target_freq_table_mean=8.55)
+    assert round(8.55, 3) == round(bw.export.export._calc_mean_speed_of_freq_tab(freq_tbl_seas_adj), 3)
     assert 'is lower than the coverage threshold value of 0.8' in str(fig_rose.get_default_bbox_extra_artists()[1])
     assert 'Some months may have very little data coverage' not in str(fig_rose.get_default_bbox_extra_artists()[1])
 

--- a/tests/test_analyse.py
+++ b/tests/test_analyse.py
@@ -289,6 +289,33 @@ def test_freq_table():
                              return_data=False, seasonal_adjustment=True, coverage_threshold=0.9)
     assert isinstance(fig_rose.get_axes()[0], mpl.projections.polar.PolarAxes)
 
+    fig_rose, freq_tbl_seas_adj = bw.freq_table(DATA.Spd40mN, DATA.Dir38mS, return_data=True, seasonal_adjustment=True,
+                                                coverage_threshold=0)
+
+    assert freq_tbl_seas_adj.sum().round(6).to_dict()['105.0-135.0'] == 5.140507
+
+    fig_rose, freq_tbl_no_seas_adj = bw.freq_table(DATA.Spd40mN, DATA.Dir38mS, return_data=True,
+                                                   seasonal_adjustment=False, coverage_threshold=0)
+
+    assert round(bw.export.export._calc_mean_speed_of_freq_tab(freq_tbl_no_seas_adj), 3) == 6.764
+    assert freq_tbl_no_seas_adj.sum().round(6).to_dict() == target_freq_dict_no_seas_adj_sum
+
+    fig_rose, freq_tbl_no_seas_adj1 = bw.freq_table(DATA.Spd40mN, DATA.Dir38mS['2016-06-01':], return_data=True,
+                                                    seasonal_adjustment=False,
+                                                    coverage_threshold=0.5)
+    fig_rose, freq_tbl_no_seas_adj2 = bw.freq_table(DATA.Spd40mN['2016-06-01':], DATA.Dir38mS, return_data=True,
+                                                    seasonal_adjustment=False,
+                                                    coverage_threshold=0.5)
+
+    assert round(bw.export.export._calc_mean_speed_of_freq_tab(freq_tbl_no_seas_adj1), 3) == round(
+        bw.export.export._calc_mean_speed_of_freq_tab(freq_tbl_no_seas_adj2), 3)
+
+    assert round(bw.export.export._calc_mean_speed_of_freq_tab(freq_tbl_no_seas_adj1), 3) == 6.713
+
+    rose, freq_table = bw.freq_table(DATA.Spd40mN, DATA.Dir38mS, return_data=True, coverage_threshold=0.5,
+                                     target_freq_table_mean=8)
+    assert round(bw.export.export._calc_mean_speed_of_freq_tab(freq_table), 3) == 8
+
 
 def test_dist():
     bw.dist(DATA[['Spd40mN']], bins=[0, 8, 12, 21], bin_labels=['normal', 'gale', 'storm'])


### PR DESCRIPTION
I have made the following updates to `freq_table`:

- make it use `_filter_out_months_based_on_coverage_threshold` function generated as part of #298. Warning messages for data coverage generated for `momm` and `freq_table` are now generated by same function and therefore similar.
- filter out both `var_series` and `direction_series` data when a coverage_threshold is given as input - this was a bug in previous version as coverage filter was based only on  `var_series` 
- added option of setting a `coverage_threshold` also for the basic method and not only for seasonal adjusted option. Similarly to `momm` (#298), I have updated the `coverage_threshold` default value to be None when no seasonal adj is applied and 0.8 with seas adj. This was done in order to avoid generating a breaking change.
- added tests and examples in docstring for new functionalities of the function 