### PR TITLE
[Iss385] `slice_data`, `offset_timestamps`, `_LoadBWPlatform.get_data` date_to not included

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ _line_colors_, _legend_ and _figure_size_. (Issue #[349](https://github.com/brig
 18. Fixed bug for `SpeedSort` where the `sector_predict` function was not interpolating data using two fit lines. (Issue #[377](https://github.com/brightwind-dev/brightwind/issues/377)).
 19. Updated `_ColorPalette` to automatically update color_list, color_map, color_map_cyclical and adjusted lightness color variables when main colors (primary, secondary etc.) are changed. (Issue #[381](https://github.com/brightwind-dev/brightwind/issues/381)).
 19. Allow `momm` function to derive a seasonal adjusted mean of monthly mean, if user sets `seasonal_adjustment` to true, and allow to apply a `coverage_threshold` (Issue #[298](https://github.com/brightwind-dev/brightwind/issues/298))
-20. Updated `slice_data`, `offset_timestamps` functions to use data up to the end of the day before the date_to value provided as input. This only if date_to is a date format and not datetime. (Issue #[385](https://github.com/brightwind-dev/brightwind/issues/385))
+20. Updated `slice_data`, `offset_timestamps`, `_LoadBWPlatform.get_data` functions to use data_to not included if provided as input. (Issue #[385](https://github.com/brightwind-dev/brightwind/issues/385))
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ _line_colors_, _legend_ and _figure_size_. (Issue #[349](https://github.com/brig
 18. Fixed bug for `SpeedSort` where the `sector_predict` function was not interpolating data using two fit lines. (Issue #[377](https://github.com/brightwind-dev/brightwind/issues/377)).
 19. Updated `_ColorPalette` to automatically update color_list, color_map, color_map_cyclical and adjusted lightness color variables when main colors (primary, secondary etc.) are changed. (Issue #[381](https://github.com/brightwind-dev/brightwind/issues/381)).
 19. Allow `momm` function to derive a seasonal adjusted mean of monthly mean, if user sets `seasonal_adjustment` to true, and allow to apply a `coverage_threshold` (Issue #[298](https://github.com/brightwind-dev/brightwind/issues/298))
+20. Updated `slice_data` function to slice data up to the end of the day before the date_to value provided as input. This only if date_to is a date format and not datetime. (Issue #[385](https://github.com/brightwind-dev/brightwind/issues/385))
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ _line_colors_, _legend_ and _figure_size_. (Issue #[349](https://github.com/brig
 18. Fixed bug for `SpeedSort` where the `sector_predict` function was not interpolating data using two fit lines. (Issue #[377](https://github.com/brightwind-dev/brightwind/issues/377)).
 19. Updated `_ColorPalette` to automatically update color_list, color_map, color_map_cyclical and adjusted lightness color variables when main colors (primary, secondary etc.) are changed. (Issue #[381](https://github.com/brightwind-dev/brightwind/issues/381)).
 19. Allow `momm` function to derive a seasonal adjusted mean of monthly mean, if user sets `seasonal_adjustment` to true, and allow to apply a `coverage_threshold` (Issue #[298](https://github.com/brightwind-dev/brightwind/issues/298))
-20. Updated `slice_data`, `offset_timestamps`, `_LoadBWPlatform.get_data` functions to use data_to not included if provided as input. (Issue #[385](https://github.com/brightwind-dev/brightwind/issues/385))
+20. Updated `slice_data`, `offset_timestamps`, `_LoadBWPlatform.get_data` functions to use 'less than' data_to if provided as input. (Issue #[385](https://github.com/brightwind-dev/brightwind/issues/385))
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ _line_colors_, _legend_ and _figure_size_. (Issue #[349](https://github.com/brig
 18. Fixed bug for `SpeedSort` where the `sector_predict` function was not interpolating data using two fit lines. (Issue #[377](https://github.com/brightwind-dev/brightwind/issues/377)).
 19. Updated `_ColorPalette` to automatically update color_list, color_map, color_map_cyclical and adjusted lightness color variables when main colors (primary, secondary etc.) are changed. (Issue #[381](https://github.com/brightwind-dev/brightwind/issues/381)).
 19. Allow `momm` function to derive a seasonal adjusted mean of monthly mean, if user sets `seasonal_adjustment` to true, and allow to apply a `coverage_threshold` (Issue #[298](https://github.com/brightwind-dev/brightwind/issues/298))
-20. Updated `slice_data` function to slice data up to the end of the day before the date_to value provided as input. This only if date_to is a date format and not datetime. (Issue #[385](https://github.com/brightwind-dev/brightwind/issues/385))
+20. Updated `slice_data`, `offset_timestamps` functions to use data up to the end of the day before the date_to value provided as input. This only if date_to is a date format and not datetime. (Issue #[385](https://github.com/brightwind-dev/brightwind/issues/385))
 
 
 

--- a/brightwind/analyse/analyse.py
+++ b/brightwind/analyse/analyse.py
@@ -377,7 +377,7 @@ def _mean_of_monthly_means_seasonal_adjusted(var_series):
     return result
 
 
-def momm(data, date_from: str = '', date_to: str = '', seasonal_adjustment=False, coverage_threshold=None):
+def momm(data, date_from=None, date_to=None, seasonal_adjustment=False, coverage_threshold=None):
     """
     Calculates and returns the mean of monthly mean speed. This accepts a DataFrame with timestamps as index column and
     another column with wind speed. You can also specify date_from and date_to to calculate the mean of monthly
@@ -399,9 +399,17 @@ def momm(data, date_from: str = '', date_to: str = '', seasonal_adjustment=False
 
     :param data:                Pandas DataFrame or Series with timestamp as index and a column with wind speed
     :type data:                 pandas.DataFrame or pandas.Series
-    :param date_from:           Start date as string in format YYYY-MM-DD
+    :param date_from:           Start date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. If format of date_from
+                                is YYYY-MM-DD, then the first timestamp of the date is used
+                                (e.g if date_from=2023-01-01 then 2023-01-01 00:00 is the first timestamp of the
+                                sliced data). If date_from is not given then the sliced data are taken up to the
+                                first timestamp of the dataset.
     :type:                      str
-    :param date_to:             End date as string in format YYYY-MM-DD
+    :param date_to:             End date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. If format date_to is
+                                YYYY-MM-DD, then the last timestamp of the previous day is used
+                                (e.g if date_to=2023-02-01 then 2023-01-31 23:50 is the last timestamp of the
+                                sliced data). If date_to is not given then the sliced data are taken up to the
+                                last timestamp of the dataset.
     :type:                      str
     :param seasonal_adjustment: Optional, False by default. If True, returns the mean of monthly mean seasonally
                                 adjusted

--- a/brightwind/analyse/analyse.py
+++ b/brightwind/analyse/analyse.py
@@ -398,7 +398,7 @@ def momm(data, date_from: str = '', date_to: str = '', seasonal_adjustment=False
     is not derived and the function will raise an error.
 
     :param data:                Pandas DataFrame or Series with timestamp as index and a column with wind speed
-    :type data:                 pd.DataFrame or pd.Series
+    :type data:                 pandas.DataFrame or pandas.Series
     :param date_from:           Start date as string in format YYYY-MM-DD
     :type:                      str
     :param date_to:             End date as string in format YYYY-MM-DD
@@ -418,7 +418,7 @@ def momm(data, date_from: str = '', date_to: str = '', seasonal_adjustment=False
                                 Default value is None, except when 'seasonal_adjustment'=True when it is 0.8.
     :type coverage_threshold:   int, float or None
     :returns:                   Long term reference speed
-    :rtype:                     panda.Dataframe
+    :rtype:                     pandas.Dataframe
 
     **Example usage**
     ::

--- a/brightwind/analyse/analyse.py
+++ b/brightwind/analyse/analyse.py
@@ -399,17 +399,17 @@ def momm(data, date_from=None, date_to=None, seasonal_adjustment=False, coverage
 
     :param data:                Pandas DataFrame or Series with timestamp as index and a column with wind speed
     :type data:                 pandas.DataFrame or pandas.Series
-    :param date_from:           Start date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. If format of date_from
-                                is YYYY-MM-DD, then the first timestamp of the date is used
-                                (e.g if date_from=2023-01-01 then 2023-01-01 00:00 is the first timestamp of the
-                                sliced data). If date_from is not given then the sliced data are taken from the
+    :param date_from:           Start date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. Start date is included in
+                                the sliced data. If format of date_from is YYYY-MM-DD, then the first timestamp of the
+                                date is used (e.g if date_from=2023-01-01 then 2023-01-01 00:00 is the first timestamp
+                                of the sliced data). If date_from is not given then the sliced data are taken from the
                                 first timestamp of the dataset.
     :type:                      str
-    :param date_to:             End date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. If format date_to is
-                                YYYY-MM-DD, then the last timestamp of the previous day is used
-                                (e.g if date_to=2023-02-01 then 2023-01-31 23:50 is the last timestamp of the
-                                sliced data). If date_to is not given then the sliced data are taken up to the
-                                last timestamp of the dataset.
+    :param date_to:             End date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. End date is not included in
+                                the sliced data. If format date_to is YYYY-MM-DD, then the last timestamp of the
+                                previous day is used (e.g if date_to=2023-02-01 then 2023-01-31 23:50 is the last
+                                timestamp of the sliced data). If date_to is not given then the sliced data are taken up
+                                to the last timestamp of the dataset.
     :type:                      str
     :param seasonal_adjustment: Optional, False by default. If True, returns the mean of monthly mean seasonally
                                 adjusted

--- a/brightwind/analyse/analyse.py
+++ b/brightwind/analyse/analyse.py
@@ -399,13 +399,13 @@ def momm(data, date_from=None, date_to=None, seasonal_adjustment=False, coverage
 
     :param data:                Pandas DataFrame or Series with timestamp as index and a column with wind speed
     :type data:                 pandas.DataFrame or pandas.Series
-    :param date_from:           Start date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. Start date is included in
+    :param date_from:           Start date as string in format YYYY-MM-DD or YYYY-MM-DD hh:mm. Start date is included in
                                 the sliced data. If format of date_from is YYYY-MM-DD, then the first timestamp of the
                                 date is used (e.g if date_from=2023-01-01 then 2023-01-01 00:00 is the first timestamp
                                 of the sliced data). If date_from is not given then the sliced data are taken from the
                                 first timestamp of the dataset.
     :type:                      str
-    :param date_to:             End date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. End date is not included in
+    :param date_to:             End date as string in format YYYY-MM-DD or YYYY-MM-DD hh:mm. End date is not included in
                                 the sliced data. If format date_to is YYYY-MM-DD, then the last timestamp of the
                                 previous day is used (e.g if date_to=2023-02-01 then 2023-01-31 23:50 is the last
                                 timestamp of the sliced data). If date_to is not given then the sliced data are taken up

--- a/brightwind/analyse/analyse.py
+++ b/brightwind/analyse/analyse.py
@@ -402,7 +402,7 @@ def momm(data, date_from=None, date_to=None, seasonal_adjustment=False, coverage
     :param date_from:           Start date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. If format of date_from
                                 is YYYY-MM-DD, then the first timestamp of the date is used
                                 (e.g if date_from=2023-01-01 then 2023-01-01 00:00 is the first timestamp of the
-                                sliced data). If date_from is not given then the sliced data are taken up to the
+                                sliced data). If date_from is not given then the sliced data are taken from the
                                 first timestamp of the dataset.
     :type:                      str
     :param date_to:             End date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. If format date_to is

--- a/brightwind/analyse/plot.py
+++ b/brightwind/analyse/plot.py
@@ -478,13 +478,13 @@ def plot_timeseries(data, date_from=None, date_to=None, x_label=None, y_label=No
 
     :param data:                    Data in the form of a Pandas DataFrame/Series to plot.
     :type data:                     pd.DataFrame, pd.Series
-    :param date_from:               Start date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. Start date is
+    :param date_from:               Start date as string in format YYYY-MM-DD or YYYY-MM-DD hh:mm. Start date is
                                     included in the sliced data. If format of date_from is YYYY-MM-DD, then the first
                                     timestamp of the date is used (e.g if date_from=2023-01-01 then 2023-01-01 00:00
                                     is the first timestamp of the sliced data). If date_from is not given then the
                                     sliced data are taken from the first timestamp of the dataset.
     :type date_from:                str
-    :param date_to:                 End date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. End date is not
+    :param date_to:                 End date as string in format YYYY-MM-DD or YYYY-MM-DD hh:mm. End date is not
                                     included in the sliced data. If format date_to is YYYY-MM-DD, then the last
                                     timestamp of the previous day is used (e.g if date_to=2023-02-01 then
                                     2023-01-31 23:50 is the last timestamp of the sliced data). If date_to is not given

--- a/brightwind/analyse/plot.py
+++ b/brightwind/analyse/plot.py
@@ -478,17 +478,17 @@ def plot_timeseries(data, date_from=None, date_to=None, x_label=None, y_label=No
 
     :param data:                    Data in the form of a Pandas DataFrame/Series to plot.
     :type data:                     pd.DataFrame, pd.Series
-    :param date_from:               Start date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. If format of
-                                    date_from is YYYY-MM-DD, then the first timestamp of the date is used
-                                    (e.g if date_from=2023-01-01 then 2023-01-01 00:00 is the first timestamp of the
-                                    sliced data). If date_from is not given then the sliced data are taken from the
-                                    first timestamp of the dataset.
+    :param date_from:               Start date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. Start date is
+                                    included in the sliced data. If format of date_from is YYYY-MM-DD, then the first
+                                    timestamp of the date is used (e.g if date_from=2023-01-01 then 2023-01-01 00:00
+                                    is the first timestamp of the sliced data). If date_from is not given then the
+                                    sliced data are taken from the first timestamp of the dataset.
     :type date_from:                str
-    :param date_to:                 End date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. If format date_to is
-                                    YYYY-MM-DD, then the last timestamp of the previous day is used
-                                    (e.g if date_to=2023-02-01 then 2023-01-31 23:50 is the last timestamp of the
-                                    sliced data). If date_to is not given then the sliced data are taken up to the
-                                    last timestamp of the dataset.
+    :param date_to:                 End date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. End date is not
+                                    included in the sliced data. If format date_to is YYYY-MM-DD, then the last
+                                    timestamp of the previous day is used (e.g if date_to=2023-02-01 then
+                                    2023-01-31 23:50 is the last timestamp of the sliced data). If date_to is not given
+                                    then the sliced data are taken up to the  last timestamp of the dataset.
     :type date_to:                  str
     :param x_label:                 Label for the x-axis. Default is None.
     :type x_label:                  str, None

--- a/brightwind/analyse/plot.py
+++ b/brightwind/analyse/plot.py
@@ -481,7 +481,7 @@ def plot_timeseries(data, date_from=None, date_to=None, x_label=None, y_label=No
     :param date_from:               Start date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. If format of
                                     date_from is YYYY-MM-DD, then the first timestamp of the date is used
                                     (e.g if date_from=2023-01-01 then 2023-01-01 00:00 is the first timestamp of the
-                                    sliced data). If date_from is not given then the sliced data are taken up to the
+                                    sliced data). If date_from is not given then the sliced data are taken from the
                                     first timestamp of the dataset.
     :type date_from:                str
     :param date_to:                 End date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. If format date_to is

--- a/brightwind/analyse/plot.py
+++ b/brightwind/analyse/plot.py
@@ -471,18 +471,24 @@ def _timeseries_subplot(x, y, x_label=None, y_label=None, x_limits=None, y_limit
     return ax
 
 
-def plot_timeseries(data, date_from='', date_to='', x_label=None, y_label=None, y_limits=None,
+def plot_timeseries(data, date_from=None, date_to=None, x_label=None, y_label=None, y_limits=None,
                     x_tick_label_angle=25, line_colors=None, legend=True, figure_size=(15, 8)):
     """
     Plot a timeseries of data.
 
     :param data:                    Data in the form of a Pandas DataFrame/Series to plot.
     :type data:                     pd.DataFrame, pd.Series
-    :param date_from:               Start date used for plotting, if not specified the first timestamp of data is
-                                    considered. Should be in yyyy-mm-dd format
+    :param date_from:               Start date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. If format of
+                                    date_from is YYYY-MM-DD, then the first timestamp of the date is used
+                                    (e.g if date_from=2023-01-01 then 2023-01-01 00:00 is the first timestamp of the
+                                    sliced data). If date_from is not given then the sliced data are taken up to the
+                                    first timestamp of the dataset.
     :type date_from:                str
-    :param date_to:                 End date used for plotting, if not specified last timestamp of data is considered.
-                                    Should be in yyyy-mm-dd format
+    :param date_to:                 End date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. If format date_to is
+                                    YYYY-MM-DD, then the last timestamp of the previous day is used
+                                    (e.g if date_to=2023-02-01 then 2023-01-31 23:50 is the last timestamp of the
+                                    sliced data). If date_to is not given then the sliced data are taken up to the
+                                    last timestamp of the dataset.
     :type date_to:                  str
     :param x_label:                 Label for the x-axis. Default is None.
     :type x_label:                  str, None

--- a/brightwind/load/load.py
+++ b/brightwind/load/load.py
@@ -1867,8 +1867,8 @@ def apply_cleaning(data, cleaning_file_or_df, inplace=False, sensor_col_name='Se
     | Spd80m | 2018-10-23 12:30:00 | 2018-10-25 14:20:00
     | Dir78m | 2018-12-23 02:40:00 |
 
-    :param data: Data to be cleaned.
-    :type data: pandas.DataFrame
+    :param data:                    Data to be cleaned.
+    :type data:                     pandas.DataFrame
     :param cleaning_file_or_df:     File path of the csv file or a pandas DataFrame which contains the list of sensor
                                     names along with the start and end timestamps of the periods that are flagged.
     :type cleaning_file_or_df:      str, pd.DataFrame

--- a/brightwind/load/load.py
+++ b/brightwind/load/load.py
@@ -1820,20 +1820,22 @@ def load_cleaning_file(filepath, date_from_col_name='Start', date_to_col_name='S
     | Spd80m | 2018-10-23 12:30:00 | 2018-10-25 14:20:00
     | Dir78m | 2018-12-23 02:40:00 |
 
-    :param filepath:  File path of the file which contains the the list of sensor names along with the start and
-           end timestamps of the periods that are flagged.
+    :param filepath:            File path of the file which contains the the list of sensor names along with the start
+                                and end timestamps of the periods that are flagged.
     :type filepath: str
-    :param date_from_col_name: The column name of the date_from or the start date of the period to be cleaned.
-    :type date_from_col_name: str, default 'Start'
-    :param date_to_col_name: The column name of the date_to or the end date of the period to be cleaned.
-    :type date_to_col_name: str, default 'Stop'
-    :param dayfirst: If your timestamp starts with the day first e.g. DD/MM/YYYY then set this to true. Pandas defaults
-            to reading 10/11/12 as 2012-10-11 (11-Oct-2012). If True, pandas parses dates with the day
-            first, eg 10/11/12 is parsed as 2012-11-10. More info on pandas.read_csv parameters.
-    :type dayfirst: bool, default False
-    :param kwargs: All the kwargs from pandas.read_csv can be passed to this function.
-    :return: A DataFrame where each row contains the sensor name and the start and end timestamps of the flagged data.
-    :rtype: pandas.DataFrame
+    :param date_from_col_name:  The column name of the date_from or the start date of the period to be cleaned.
+    :type date_from_col_name:   str, default 'Start'
+    :param date_to_col_name:    The column name of the date_to or the end date of the period to be cleaned.
+    :type date_to_col_name:     str, default 'Stop'
+    :param dayfirst:            If your timestamp starts with the day first e.g. DD/MM/YYYY then set this to true.
+                                Pandas defaults to reading 10/11/12 as 2012-10-11 (11-Oct-2012). If True, pandas parses
+                                dates with the day first, eg 10/11/12 is parsed as 2012-11-10. More info on
+                                pandas.read_csv parameters.
+    :type dayfirst:             bool, default False
+    :param kwargs:              All the kwargs from pandas.read_csv can be passed to this function.
+    :return:                    A DataFrame where each row contains the sensor name and the start and end timestamps of
+                                the flagged data.
+    :rtype:                     pandas.DataFrame
 
     **Example usage**
     ::

--- a/brightwind/load/load.py
+++ b/brightwind/load/load.py
@@ -1869,30 +1869,31 @@ def apply_cleaning(data, cleaning_file_or_df, inplace=False, sensor_col_name='Se
 
     :param data: Data to be cleaned.
     :type data: pandas.DataFrame
-    :param cleaning_file_or_df: File path of the csv file or a pandas DataFrame which contains the list of sensor
-                                names along with the start and end timestamps of the periods that are flagged.
-    :type cleaning_file_or_df: str, pd.DataFrame
-    :param inplace: If 'inplace' is True, the original data, 'data', will be modified and and replaced with the cleaned
-                    data. If 'inplace' is False, the original data will not be touched and instead a new object
-                    containing the cleaned data is created. To store this cleaned data, please ensure it is assigned
-                    to a new variable.
+    :param cleaning_file_or_df:     File path of the csv file or a pandas DataFrame which contains the list of sensor
+                                    names along with the start and end timestamps of the periods that are flagged.
+    :type cleaning_file_or_df:      str, pd.DataFrame
+    :param inplace:                 If 'inplace' is True, the original data, 'data', will be modified and and replaced
+                                    with the cleaned data. If 'inplace' is False, the original data will not be touched
+                                    and instead a new object containing the cleaned data is created. To store this
+                                    cleaned data, please ensure it is assigned to a new variable.
     :type inplace: Boolean
-    :param sensor_col_name: The column name which contains the list of sensor names that have flagged periods.
-    :type sensor_col_name: str, default 'Sensor'
-    :param date_from_col_name: The column name of the date_from or the start date of the period to be cleaned.
-    :type date_from_col_name: str, default 'Start'
-    :param date_to_col_name: The column name of the date_to or the end date of the period to be cleaned.
-    :type date_to_col_name: str, default 'Stop'
-    :param all_sensors_descriptor: A text descriptor that represents ALL sensors in the DataFrame.
-    :type all_sensors_descriptor: str, default 'All'
-    :param replacement_text: Text used to replace the flagged data.
-    :type replacement_text: str, default 'NaN'
-    :param dayfirst: If your timestamp starts with the day first e.g. DD/MM/YYYY then set this to true. Pandas defaults
-            to reading 10/11/12 as 2012-10-11 (11-Oct-2012). If True, pandas parses dates with the day
-            first, eg 10/11/12 is parsed as 2012-11-10. More info on pandas.read_csv parameters.
-    :type dayfirst: bool, default False
-    :return: DataFrame with the flagged data removed.
-    :rtype: pandas.DataFrame
+    :param sensor_col_name:         The column name which contains the list of sensor names that have flagged periods.
+    :type sensor_col_name:          str, default 'Sensor'
+    :param date_from_col_name:      The column name of the date_from or the start date of the period to be cleaned.
+    :type date_from_col_name:       str, default 'Start'
+    :param date_to_col_name:        The column name of the date_to or the end date of the period to be cleaned.
+    :type date_to_col_name:         str, default 'Stop'
+    :param all_sensors_descriptor:  A text descriptor that represents ALL sensors in the DataFrame.
+    :type all_sensors_descriptor:   str, default 'All'
+    :param replacement_text:        Text used to replace the flagged data.
+    :type replacement_text:         str, default 'NaN'
+    :param dayfirst:                If your timestamp starts with the day first e.g. DD/MM/YYYY then set this to true.
+                                    Pandas defaults to reading 10/11/12 as 2012-10-11 (11-Oct-2012). If True, pandas
+                                    parses dates with the day first, eg 10/11/12 is parsed as 2012-11-10.
+                                    More info on pandas.read_csv parameters.
+    :type dayfirst:                 bool, default False
+    :return:                        DataFrame with the flagged data removed.
+    :rtype:                         pandas.DataFrame
 
     **Example usage**
     ::

--- a/brightwind/load/load.py
+++ b/brightwind/load/load.py
@@ -1606,14 +1606,16 @@ class _LoadBWPlatform:
         """
         Retrieve measurement data from the brightwind platform and return it in a DataFrame with index as Timestamp.
 
-        :param measurement_location_uuid: The measurement location uuid.
-        :type measurement_location_uuid: str or uuid
-        :param from_date: Datetime representing the start of the measurement period you want.
-        :type from_date: datetime or str
-        :param to_date: Datetime representing the end of the measurement period you want.
-        :type to_date: datetime or str
-        :return: DataFrame with index as a timestamp.
-        :rtype: pd.DataFrame
+        :param measurement_location_uuid:   The measurement location uuid.
+        :type measurement_location_uuid:    str or uuid
+        :param from_date:                   Datetime representing the start of the measurement period you want
+                                            (included).
+        :type from_date:                    datetime or str
+        :param to_date:                     Datetime representing the end of the measurement period you want
+                                            (not included).
+        :type to_date:                      datetime or str
+        :return:                            DataFrame with index as a timestamp.
+        :rtype:                             pd.DataFrame
 
         **Example usage**
         ::
@@ -1645,7 +1647,7 @@ class _LoadBWPlatform:
         if isinstance(from_date, str):
             from_date = parse(from_date)
         if isinstance(to_date, str):
-            to_date = parse(to_date)
+            to_date = parse(to_date) - datetime.timedelta(seconds=1)
 
         response = requests.get(_LoadBWPlatform._base_url + '/api/resource-data-measurement-location', params={
             'measurement_location_uuid': measurement_location_uuid,

--- a/brightwind/transform/transform.py
+++ b/brightwind/transform/transform.py
@@ -1270,8 +1270,9 @@ def offset_timestamps(data, offset, date_from=None, date_to=None, overwrite=Fals
     """
     Offset timestamps by a certain time period
 
-    :param data:        DateTimeIndex or Series/DataFrame with DateTimeIndex
-    :type data:         pandas.DateTimeIndex, pandas.Series, pandas.DataFrame
+    :param data:        The timestamp or DateTimeIndex or Dataframe or Series to which apply the time offset.
+    :type data:         pandas.DateTimeIndex, pandas.Series, pandas.DataFrame, pandas.Timestamp, datetime.datetime,
+                        datetime.date, datetime.time
     :param offset:      A string specifying the time to offset the time-series.
 
                         - Set offset to 10min to add 10 minutes to each timestamp, -10min to subtract 10 minutes and so
@@ -1300,50 +1301,74 @@ def offset_timestamps(data, offset, date_from=None, date_to=None, overwrite=Fals
     :param overwrite:   Change to True to overwrite the unadjusted timestamps if they are same outside of the slice of
                         data you want to offset. False by default.
     :type overwrite:    bool
-    :returns:           Offsetted DateTimeIndex/Series/DataFrame, same format is input data
+    :returns:           Offsetted Timestamp/DateTimeIndex/Series/DataFrame/datetime.datetime/datetime.time,
+                        same format is input data
 
     **Example usage**
     ::
         import brightwind as bw
-        data = bw.load_campbell_scientific(bw.demo_datasets.demo_site_data)
+        data = bw.load_csv(bw.demo_datasets.demo_data)
 
-        #To decrease 10 minutes within a given date range and overwrite the original data
-        op1 = bw.offset_timestamps(data, offset='1H', date_from='2016-01-01 00:20:00',
-            date_to='2016-01-01 01:40:00', overwrite=True)
+        # To decrease 10 minutes within a given date range and overwrite the original data
+        op1 = bw.offset_timestamps(data, offset='1H', date_from='2016-02-01 00:20:00',
+            date_to='2016-02-01 01:40:00', overwrite=True)
 
-        #To decrease 10 minutes within a given date range not overwriting the original data
-        op2 = bw.offset_timestamps(data, offset='-10min', date_from='2016-01-01 00:20:00',
-            date_to='2016-01-01 01:40:00')
+        # To decrease 10 minutes within a given date range not overwriting the original data
+        op2 = bw.offset_timestamps(data, offset='-10min', date_from='2016-02-01 00:20:00',
+            date_to='2016-02-01 01:40:00')
 
-        #Can accept Series or index as input
-        op3 = bw.offset_timestamps(data.Spd80mS, offset='1D', date_from='2016-01-01 00:20:00')
+        # To decrease 30 minutes within a given date range not overwriting the original data and giving as input dates
+        # for date_from and date_to
+        op2 = bw.offset_timestamps(DATA, offset='-30min', date_from='2016-01-09', date_to='2016-01-10')
 
-        op4 = bw.offset_timestamps(data.index, offset='-10min', date_from='2016-01-01 00:20:00',
-            date_from='2016-01-01 01:40:00')
+        # Can accept Series or index as input
+        op3 = bw.offset_timestamps(data.Spd80mS, offset='1D', date_from='2016-02-01 00:20:00')
 
-        #Can also except decimal values for offset, like 3.5H for 3 hours and 30 minutes
+        op4 = bw.offset_timestamps(data.index, offset='-10min', date_from='2016-02-01 00:20:00',
+            date_to='2016-02-01 01:40:00')
 
-        op5 = bw.offset_timestamps(data.index, offset='3.5H', date_from='2016-01-01 00:20:00',
-            date_from='2016-01-01 01:40:00')
+        # Can also except decimal values for offset, like 3.5H for 3 hours and 30 minutes
+        op5 = bw.offset_timestamps(data.index, offset='3.5H', date_from='2016-02-01 00:20:00',
+            date_to='2016-02-01 01:40:00')
+
+        # Can accept also Timestamp and datetime objects
+        bw.offset_timestamps(data.index[0], offset='4H')
+        bw.offset_timestamps(datetime.datetime(2016, 2, 1, 0, 20), offset='3.5H')
+        bw.offset_timestamps(datetime.date(2016, 2, 1), offset='-5H')
+        bw.offset_timestamps(datetime.time(0, 20), offset='30min')
 
     """
-    
-    date_from = pd.to_datetime(date_from)
-    date_to = pd.to_datetime(date_to)
 
-    if isinstance(data, pd.Timestamp) or isinstance(data, datetime.date)\
-            or isinstance(data, datetime.time)\
-            or isinstance(data, datetime.datetime):
+    if pd.isnull(date_from):
+        if isinstance(data, pd.DatetimeIndex):
+            date_from = data[0]
+        elif isinstance(data, pd.Series) or isinstance(data, pd.DataFrame):
+            date_from = data.index[0]
+    else:
+        date_from = pd.to_datetime(date_from)
+
+    if pd.isnull(date_to):
+        if isinstance(data, pd.DatetimeIndex):
+            date_to = data[-1]
+        elif isinstance(data, pd.Series) or isinstance(data, pd.DataFrame):
+            date_to = data.index[-1]
+    elif (pd.to_datetime(date_to, format="%Y-%m-%d %H:%M").time() == datetime.time(0)) and len(date_to) <= 10:
+        date_to = pd.to_datetime(date_to, format="%Y-%m-%d") - datetime.timedelta(seconds=1)
+    else:
+        date_to = pd.to_datetime(date_to)
+
+    if isinstance(data, pd.Timestamp):
         return data + _freq_str_to_dateoffset(offset)
 
-    if isinstance(data, pd.DatetimeIndex):
+    elif isinstance(data, datetime.date)\
+            or isinstance(data, datetime.datetime):
+        return (data + _freq_str_to_dateoffset(offset)).to_pydatetime()
+
+    elif isinstance(data, datetime.time):
+        return (datetime.datetime.combine(datetime.date.today(), data) + _freq_str_to_dateoffset(offset)).time()
+
+    elif isinstance(data, pd.DatetimeIndex):
         original = pd.to_datetime(data.values)
-
-        if pd.isnull(date_from):
-            date_from = data[0]
-
-        if pd.isnull(date_to):
-            date_to = data[-1]
 
         shifted_slice = original[(original >= date_from) & (original <= date_to)] + _freq_str_to_dateoffset(offset)
         shifted = original[original < date_from].append(shifted_slice)
@@ -1351,18 +1376,13 @@ def offset_timestamps(data, offset, date_from=None, date_to=None, overwrite=Fals
         shifted = shifted.drop_duplicates().sort_values()
         return pd.DatetimeIndex(shifted)
 
-    if isinstance(data, pd.Series) or isinstance(data, pd.DataFrame):
+    elif isinstance(data, pd.Series) or isinstance(data, pd.DataFrame):
 
         if not isinstance(data.index, pd.DatetimeIndex):
             raise TypeError('Input must have datetime index')
         else:
             original = pd.to_datetime(data.index.values)
             df_copy = data.copy(deep=False)
-            if pd.isnull(date_from):
-                date_from = data.index[0]
-
-            if pd.isnull(date_to):
-                date_to = data.index[-1]
 
             shifted_slice = original[(original >= date_from) & (original <= date_to)] + _freq_str_to_dateoffset(offset)
             intersection_front = original[(original < date_from)].intersection(shifted_slice)

--- a/brightwind/transform/transform.py
+++ b/brightwind/transform/transform.py
@@ -1288,15 +1288,17 @@ def offset_timestamps(data, offset, date_from=None, date_to=None, overwrite=Fals
                           for 2Y, 3Y, etc.
 
     :type offset:       str
-    :param date_from:   (Optional) The timestamp from input data where to start offsetting from. If format of date_from
-                        is YYYY-MM-DD, then the first timestamp of the date is used (e.g if date_from=2023-01-01 then
-                        2023-01-01 00:00 is the first timestamp of when to start offsetting from). If date_from is not
-                        given then the offset is applied from the first timestamp of the dataset.
+    :param date_from:   (Optional) The timestamp from input data where to start offsetting from. Start date is
+                        included in the offsetted data. If format of date_from is YYYY-MM-DD, then the first timestamp
+                        of the date is used (e.g if date_from=2023-01-01 then 2023-01-01 00:00 is the first timestamp of
+                        when to start offsetting from). If date_from is not given then the offset is applied from the
+                        first timestamp of the dataset.
     :type date_from:    str, datetime, dict
-    :param date_to:     (Optional) The timestamp from input data where to end offsetting. If format date_to is
-                        YYYY-MM-DD, then the last timestamp of the previous day is used (e.g if date_to=2023-02-01 then
-                        2023-01-31 23:50 is the last timestamp of when to end offsetting to). If date_to is not given
-                        then the offset is applied up to the last timestamp of the dataset.
+    :param date_to:     (Optional) The timestamp from input data where to end offsetting. End date is not included in
+                        the offsetted data. If format date_to is YYYY-MM-DD, then the last timestamp of the previous day
+                        is used (e.g if date_to=2023-02-01 then 2023-01-31 23:50 is the last timestamp of when to end
+                        offsetting to). If date_to is not given then the offset is applied up to the last timestamp of
+                        the dataset.
     :type date_to:      str, datetime, dict
     :param overwrite:   Change to True to overwrite the unadjusted timestamps if they are same outside of the slice of
                         data you want to offset. False by default.
@@ -1352,10 +1354,8 @@ def offset_timestamps(data, offset, date_from=None, date_to=None, overwrite=Fals
             date_to = data[-1]
         elif isinstance(data, pd.Series) or isinstance(data, pd.DataFrame):
             date_to = data.index[-1]
-    elif (pd.to_datetime(date_to, format="%Y-%m-%d %H:%M").time() == datetime.time(0)) and len(date_to) <= 10:
-        date_to = pd.to_datetime(date_to, format="%Y-%m-%d") - datetime.timedelta(seconds=1)
     else:
-        date_to = pd.to_datetime(date_to)
+        date_to = pd.to_datetime(date_to) - datetime.timedelta(seconds=1)
 
     if isinstance(data, pd.Timestamp):
         return data + _freq_str_to_dateoffset(offset)

--- a/brightwind/transform/transform.py
+++ b/brightwind/transform/transform.py
@@ -1270,27 +1270,37 @@ def offset_timestamps(data, offset, date_from=None, date_to=None, overwrite=Fals
     """
     Offset timestamps by a certain time period
 
-    :param data: DateTimeIndex or Series/DataFrame with DateTimeIndex
-    :type data: pandas.DateTimeIndex, pandas.Series, pandas.DataFrame
-    :param offset: A string specifying the time to offset the time-series.
+    :param data:        DateTimeIndex or Series/DataFrame with DateTimeIndex
+    :type data:         pandas.DateTimeIndex, pandas.Series, pandas.DataFrame
+    :param offset:      A string specifying the time to offset the time-series.
 
-            - Set offset to 10min to add 10 minutes to each timestamp, -10min to subtract 10 minutes and so on
-                for 4min, 20min, etc.
-            - Set offset to 1H to add 1 hour to each timestamp and -1H to subtract and so on for 5H, 6H, etc.
-            - Set offset to 1D to add a day and -1D to subtract and so on for 5D, 7D, 15D, etc.
-            - Set offset to 1W to add a week and -1W to subtract from each timestamp and so on for 2W, 4W, etc.
-            - Set offset to 1M to add a month and -1M to subtract a month from each timestamp and so on for 2M, 3M, etc.
-            - Set offset to 1Y to add an year and -1Y to subtract an year from each timestamp and so on for 2Y, 3Y, etc.
+                        - Set offset to 10min to add 10 minutes to each timestamp, -10min to subtract 10 minutes and so
+                          on for 4min, 20min, etc.
+                        - Set offset to 1H to add 1 hour to each timestamp and -1H to subtract and so on for 5H, 6H,
+                          etc.
+                        - Set offset to 1D to add a day and -1D to subtract and so on for 5D, 7D, 15D, etc.
+                        - Set offset to 1W to add a week and -1W to subtract from each timestamp and so on for 2W,
+                          4W, etc.
+                        - Set offset to 1M to add a month and -1M to subtract a month from each timestamp and so on
+                          for 2M, 3M, etc.
+                        - Set offset to 1Y to add an year and -1Y to subtract an year from each timestamp and so on
+                          for 2Y, 3Y, etc.
 
-    :type offset: str
-    :param date_from: (Optional) The timestamp from input data where to start offsetting from.
-    :type date_from: str, datetime, dict
-    :param date_to: (Optional) The timestamp from input data where to end offsetting.
-    :type date_to: str, datetime, dict
-    :param overwrite: Change to True to overwrite the unadjusted timestamps if they are same outside of the slice of
-        data you want to offset. False by default.
-    :type overwrite: bool
-    :returns: Offsetted DateTimeIndex/Series/DataFrame, same format is input data
+    :type offset:       str
+    :param date_from:   (Optional) The timestamp from input data where to start offsetting from. If format of date_from
+                        is YYYY-MM-DD, then the first timestamp of the date is used (e.g if date_from=2023-01-01 then
+                        2023-01-01 00:00 is the first timestamp of when to start offsetting from). If date_from is not
+                        given then the offset is applied from the first timestamp of the dataset.
+    :type date_from:    str, datetime, dict
+    :param date_to:     (Optional) The timestamp from input data where to end offsetting. If format date_to is
+                        YYYY-MM-DD, then the last timestamp of the previous day is used (e.g if date_to=2023-02-01 then
+                        2023-01-31 23:50 is the last timestamp of when to end offsetting to). If date_to is not given
+                        then the offset is applied up to the last timestamp of the dataset.
+    :type date_to:      str, datetime, dict
+    :param overwrite:   Change to True to overwrite the unadjusted timestamps if they are same outside of the slice of
+                        data you want to offset. False by default.
+    :type overwrite:    bool
+    :returns:           Offsetted DateTimeIndex/Series/DataFrame, same format is input data
 
     **Example usage**
     ::

--- a/brightwind/utils/utils.py
+++ b/brightwind/utils/utils.py
@@ -98,12 +98,15 @@ def slice_data(data, date_from=None, date_to=None):
     if pd.isnull(date_to):
         date_to = data.index[-1]
     else:
-        date_to = pd.to_datetime(date_to, format="%Y-%m-%d %H:%M") - datetime.timedelta(seconds=1)
+        date_to = pd.to_datetime(date_to, format="%Y-%m-%d %H:%M")
 
     if date_to < date_from:
         raise ValueError('date_to must be greater than date_from')
 
-    return data.loc[date_from:date_to]
+    if date_to == data.index[-1]:
+        return data[(data.index >= date_from)]
+    else:
+        return data[(data.index >= date_from) & (data.index < date_to)]
 
 
 def is_float_or_int(value):

--- a/brightwind/utils/utils.py
+++ b/brightwind/utils/utils.py
@@ -56,7 +56,7 @@ def validate_coverage_threshold(coverage_threshold):
     return coverage_threshold
 
 
-def slice_data(data, date_from, date_to):
+def slice_data(data, date_from='', date_to=''):
     """
     Returns the slice of data between the two date or datetime ranges.
 
@@ -64,11 +64,13 @@ def slice_data(data, date_from, date_to):
     :type data:         pandas.DataFrame or pandas.Series
     :param date_from:   Start date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. If format of input start date is
                         YYYY-MM-DD, then the first timestamp of the date is used (e.g if date_from=2023-01-01 then
-                        2023-01-01 00:00 is the first timestamp of the sliced data).
+                        2023-01-01 00:00 is the first timestamp of the sliced data). If date_from is not given then
+                        the sliced data are taken up to the first timestamp of the dataset.
     :type:              str
     :param date_to:     End date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. If fomat of input end date is
                         YYYY-MM-DD, then the last timestamp of the previous day is used (e.g if date_to=2023-02-01 then
-                        2023-01-31 23:50 is the last timestamp of the sliced data).
+                        2023-01-31 23:50 is the last timestamp of the sliced data). If date_to is not given then
+                        the sliced data are taken up to the last timestamp of the dataset.
     :type:              str
     :returns:           Sliced data
     :rtype:             pandas.Dataframe or pandas.Series
@@ -84,9 +86,14 @@ def slice_data(data, date_from, date_to):
         # Return the slice of data between two input dates
         data_sliced = bw.utils.utils.slice_data(DATA, date_from='2016-11-23', date_to='2017-10-23')
 
+        # Return the slice of data from an input date up to the end of the dataset.
+        data_sliced = bw.utils.utils.slice_data(DATA, date_from='2016-11-23')
+
     """
     date_from = pd.to_datetime(date_from, format="%Y-%m-%d %H:%M")
-    if (pd.to_datetime(date_to, format="%Y-%m-%d %H:%M").time() == datetime.time(0)) and len(date_to) <= 10:
+    if date_to is '':
+        date_to = pd.to_datetime(date_to, format="%Y-%m-%d")
+    elif (pd.to_datetime(date_to, format="%Y-%m-%d %H:%M").time() == datetime.time(0)) and len(date_to) <= 10:
         date_to = pd.to_datetime(date_to, format="%Y-%m-%d") - datetime.timedelta(seconds=1)
     else:
         date_to = pd.to_datetime(date_to, format="%Y-%m-%d")

--- a/brightwind/utils/utils.py
+++ b/brightwind/utils/utils.py
@@ -65,7 +65,7 @@ def slice_data(data, date_from=None, date_to=None):
     :param date_from:   Start date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. If format of date_from is
                         YYYY-MM-DD, then the first timestamp of the date is used (e.g if date_from=2023-01-01 then
                         2023-01-01 00:00 is the first timestamp of the sliced data). If date_from is not given then
-                        the sliced data are taken up to the first timestamp of the dataset.
+                        the sliced data are taken from the first timestamp of the dataset.
     :type:              str
     :param date_to:     End date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. If format date_to is
                         YYYY-MM-DD, then the last timestamp of the previous day is used (e.g if date_to=2023-02-01 then

--- a/brightwind/utils/utils.py
+++ b/brightwind/utils/utils.py
@@ -62,12 +62,12 @@ def slice_data(data, date_from=None, date_to=None):
 
     :param data:        Pandas DataFrame or Series with timestamp as index.
     :type data:         pandas.DataFrame or pandas.Series
-    :param date_from:   Start date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. Start date is included in the
+    :param date_from:   Start date as string in format YYYY-MM-DD or YYYY-MM-DD hh:mm. Start date is included in the
                         sliced data. If format of date_from is YYYY-MM-DD, then the first timestamp of the date is used
                         (e.g if date_from=2023-01-01 then 2023-01-01 00:00 is the first timestamp of the sliced data).
                         If date_from is not given then sliced data are taken from the first timestamp of the dataset.
     :type:              str
-    :param date_to:     End date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. End date is not included in the
+    :param date_to:     End date as string in format YYYY-MM-DD or YYYY-MM-DD hh:mm. End date is not included in the
                         sliced data. If format date_to is YYYY-MM-DD, then the last timestamp of the previous day is
                         used (e.g if date_to=2023-02-01 then 2023-01-31 23:50 is the last timestamp of the sliced data).
                         If date_to is not given then sliced data are taken up to the last timestamp of the dataset.

--- a/brightwind/utils/utils.py
+++ b/brightwind/utils/utils.py
@@ -62,15 +62,15 @@ def slice_data(data, date_from=None, date_to=None):
 
     :param data:        Pandas DataFrame or Series with timestamp as index.
     :type data:         pandas.DataFrame or pandas.Series
-    :param date_from:   Start date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. If format of date_from is
-                        YYYY-MM-DD, then the first timestamp of the date is used (e.g if date_from=2023-01-01 then
-                        2023-01-01 00:00 is the first timestamp of the sliced data). If date_from is not given then
-                        the sliced data are taken from the first timestamp of the dataset.
+    :param date_from:   Start date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. Start date is included in the
+                        sliced data. If format of date_from is YYYY-MM-DD, then the first timestamp of the date is used
+                        (e.g if date_from=2023-01-01 then 2023-01-01 00:00 is the first timestamp of the sliced data).
+                        If date_from is not given then sliced data are taken from the first timestamp of the dataset.
     :type:              str
-    :param date_to:     End date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. If format date_to is
-                        YYYY-MM-DD, then the last timestamp of the previous day is used (e.g if date_to=2023-02-01 then
-                        2023-01-31 23:50 is the last timestamp of the sliced data). If date_to is not given then
-                        the sliced data are taken up to the last timestamp of the dataset.
+    :param date_to:     End date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. End date is not included in the
+                        sliced data. If format date_to is YYYY-MM-DD, then the last timestamp of the previous day is
+                        used (e.g if date_to=2023-02-01 then 2023-01-31 23:50 is the last timestamp of the sliced data).
+                        If date_to is not given then sliced data are taken up to the last timestamp of the dataset.
     :type:              str
     :returns:           Sliced data
     :rtype:             pandas.Dataframe or pandas.Series
@@ -97,10 +97,8 @@ def slice_data(data, date_from=None, date_to=None):
 
     if pd.isnull(date_to):
         date_to = data.index[-1]
-    elif (pd.to_datetime(date_to, format="%Y-%m-%d %H:%M").time() == datetime.time(0)) and len(date_to) <= 10:
-        date_to = pd.to_datetime(date_to, format="%Y-%m-%d") - datetime.timedelta(seconds=1)
     else:
-        date_to = pd.to_datetime(date_to, format="%Y-%m-%d")
+        date_to = pd.to_datetime(date_to, format="%Y-%m-%d") - datetime.timedelta(seconds=1)
 
     if date_to < date_from:
         raise ValueError('date_to must be greater than date_from')

--- a/brightwind/utils/utils.py
+++ b/brightwind/utils/utils.py
@@ -56,18 +56,18 @@ def validate_coverage_threshold(coverage_threshold):
     return coverage_threshold
 
 
-def slice_data(data, date_from='', date_to=''):
+def slice_data(data, date_from=None, date_to=None):
     """
     Returns the slice of data between the two date or datetime ranges.
 
     :param data:        Pandas DataFrame or Series with timestamp as index.
     :type data:         pandas.DataFrame or pandas.Series
-    :param date_from:   Start date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. If format of input start date is
+    :param date_from:   Start date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. If format of date_from is
                         YYYY-MM-DD, then the first timestamp of the date is used (e.g if date_from=2023-01-01 then
                         2023-01-01 00:00 is the first timestamp of the sliced data). If date_from is not given then
                         the sliced data are taken up to the first timestamp of the dataset.
     :type:              str
-    :param date_to:     End date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. If fomat of input end date is
+    :param date_to:     End date as string in format YYYY-MM-DD or YYYY-MM-DD HH:DD. If format date_to is
                         YYYY-MM-DD, then the last timestamp of the previous day is used (e.g if date_to=2023-02-01 then
                         2023-01-31 23:50 is the last timestamp of the sliced data). If date_to is not given then
                         the sliced data are taken up to the last timestamp of the dataset.
@@ -90,19 +90,17 @@ def slice_data(data, date_from='', date_to=''):
         data_sliced = bw.utils.utils.slice_data(DATA, date_from='2016-11-23')
 
     """
-    date_from = pd.to_datetime(date_from, format="%Y-%m-%d %H:%M")
-    if date_to is '':
-        date_to = pd.to_datetime(date_to, format="%Y-%m-%d")
+    if pd.isnull(date_from):
+        date_from = data.index[0]
+    else:
+        date_from = pd.to_datetime(date_from, format="%Y-%m-%d %H:%M")
+
+    if pd.isnull(date_to):
+        date_to = data.index[-1]
     elif (pd.to_datetime(date_to, format="%Y-%m-%d %H:%M").time() == datetime.time(0)) and len(date_to) <= 10:
         date_to = pd.to_datetime(date_to, format="%Y-%m-%d") - datetime.timedelta(seconds=1)
     else:
         date_to = pd.to_datetime(date_to, format="%Y-%m-%d")
-
-    if pd.isnull(date_from):
-        date_from = data.index[0]
-
-    if pd.isnull(date_to):
-        date_to = data.index[-1]
 
     if date_to < date_from:
         raise ValueError('date_to must be greater than date_from')

--- a/brightwind/utils/utils.py
+++ b/brightwind/utils/utils.py
@@ -98,7 +98,7 @@ def slice_data(data, date_from=None, date_to=None):
     if pd.isnull(date_to):
         date_to = data.index[-1]
     else:
-        date_to = pd.to_datetime(date_to, format="%Y-%m-%d") - datetime.timedelta(seconds=1)
+        date_to = pd.to_datetime(date_to, format="%Y-%m-%d %H:%M") - datetime.timedelta(seconds=1)
 
     if date_to < date_from:
         raise ValueError('date_to must be greater than date_from')

--- a/tests/test_analyse.py
+++ b/tests/test_analyse.py
@@ -37,13 +37,13 @@ def test_momm():
 
     # Derive mean of monthly mean with standard method only using a certain period
     momm_standard = bw.momm(DATA[['Spd40mN', 'Spd40mS']], date_from='2016-06-01', date_to='2017-05-31 00:00')
-    assert round(momm_standard.T['Spd40mS'].values[0], 6) == 6.684251
+    assert round(momm_standard.T['Spd40mS'].values[0], 6) == 6.684235
 
     # Derive mean of monthly mean with standard method only using a certain period and imposing coverage_threshold
     # equal to 0.7
     momm_standard = bw.momm(DATA[['Spd40mN', 'Spd40mS']], date_from='2016-05-01', date_to='2017-05-31 00:00',
                             coverage_threshold=0.7)
-    assert round(momm_standard.T['Spd40mS'].values[0], 6) == 6.684251
+    assert round(momm_standard.T['Spd40mS'].values[0], 6) == 6.684235
 
     # Derive mean of monthly mean seasonal adjusted and imposing coverage_threshold equal to 0.7
     momm_seas_adj = bw.momm(DATA[['Spd40mN', 'Spd40mS']], seasonal_adjustment=True, coverage_threshold=0.7)

--- a/tests/test_analyse.py
+++ b/tests/test_analyse.py
@@ -36,12 +36,12 @@ def test_momm():
     assert round(momm_standard.T['Spd40mN'].values[0], 6) == 6.802488
 
     # Derive mean of monthly mean with standard method only using a certain period
-    momm_standard = bw.momm(DATA[['Spd40mN', 'Spd40mS']], date_from='2016-06-01', date_to='2017-05-31')
+    momm_standard = bw.momm(DATA[['Spd40mN', 'Spd40mS']], date_from='2016-06-01', date_to='2017-05-31 00:00')
     assert round(momm_standard.T['Spd40mS'].values[0], 6) == 6.684251
 
     # Derive mean of monthly mean with standard method only using a certain period and imposing coverage_threshold
     # equal to 0.7
-    momm_standard = bw.momm(DATA[['Spd40mN', 'Spd40mS']], date_from='2016-05-01', date_to='2017-05-31',
+    momm_standard = bw.momm(DATA[['Spd40mN', 'Spd40mS']], date_from='2016-05-01', date_to='2017-05-31 00:00',
                             coverage_threshold=0.7)
     assert round(momm_standard.T['Spd40mS'].values[0], 6) == 6.684251
 

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,6 +1,8 @@
 import pytest
 import brightwind as bw
 import os
+import pandas as pd
+import numpy as np
 
 DEMO_DATA_FOLDER = os.path.join(os.path.dirname(__file__), '../brightwind/demo_datasets')
 
@@ -20,6 +22,18 @@ def test_apply_cleaning():
     data_clnd4 = bw.apply_cleaning(data, os.path.join(DEMO_DATA_FOLDER, 'demo_cleaning_file2.csv'), dayfirst=True)
     data_clnd5 = bw.apply_cleaning(data, os.path.join(DEMO_DATA_FOLDER, 'demo_cleaning_file3.csv'), dayfirst=True)
 
+    cleaning_dict = {0: {'Sensor': 'All', 'Start': '2016-01-09 15:30:00', 'Stop': '2016-01-09 17:10:00',
+                         'Reason': 'Installation'},
+                     1: {'Sensor': 'Spd', 'Start': '2016-03-09 06:20:00', 'Stop': '2016-03-11',
+                         'Reason': 'Icing'},
+                     2: {'Sensor': 'Dir', 'Start': '2016-03-09 06:20:00', 'Stop': '2016-03-11',
+                         'Reason': 'Icing'},
+                     3: {'Sensor': 'Spd', 'Start': '2016-03-29', 'Stop': '2016-03-30 07:10:00',
+                         'Reason': 'Icing'},
+                     4: {'Sensor': 'Dir', 'Start': '2016-03-29 ', 'Stop': '2016-03-30 07:10:00',
+                         'Reason': 'Icing'}}
+    data_clnd6 = bw.apply_cleaning(data, pd.DataFrame(cleaning_dict).T)
+
     assert (data_clnd2.drop(['RECORD', 'Site', 'LoggerID'], axis=1).fillna(-999) ==
             data_clnd3.drop(['RECORD', 'Site', 'LoggerID'], axis=1).fillna(-999)).all().all()
 
@@ -28,6 +42,13 @@ def test_apply_cleaning():
 
     assert (data_clnd3.drop(['RECORD', 'Site', 'LoggerID'], axis=1).fillna(-999) ==
             data_clnd5.drop(['RECORD', 'Site', 'LoggerID'], axis=1).fillna(-999)).all().all()
+
+    assert np.isnan(data_clnd6.Spd40mN['2016-03-09 06:20:00'])
+    assert not np.isnan(data_clnd6.Spd40mN['2016-03-09 06:10:00'])
+    assert np.isnan(data_clnd6.Spd40mN['2016-03-10 23:50:00'])
+    assert not np.isnan(data_clnd6.Spd40mN['2016-03-11 00:00:00'])
+    assert not np.isnan(data_clnd6.Spd40mN['2016-03-28 23:50'])
+    assert np.isnan(data_clnd6.Spd40mN['2016-03-29 00:00'])
 
 
 def test_load_csv():

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -38,12 +38,12 @@ def test_plot_timeseries():
     bw.plot_timeseries(DATA[['Spd40mN', 'Spd60mS', 'T2m']])
     bw.plot_timeseries(DATA[['Spd40mN']], date_from='2017-09-01')
     bw.plot_timeseries(DATA.Spd40mN, date_from='2017-09-01', x_label='Time', y_label='Spd40mN', legend=False)
-    bw.plot_timeseries(DATA.Spd40mN, date_to='2017-10-01')
-    bw.plot_timeseries(DATA.Spd40mN, date_from='2017-09-01', date_to='2017-10-01', x_tick_label_angle=25)
-    bw.plot_timeseries(DATA.Spd40mN, date_from='2017-09-01', date_to='2017-10-01', y_limits=(0, None))
-    bw.plot_timeseries(DATA.Spd40mN, date_from='2017-09-01', date_to='2017-10-01', y_limits=None)
-    bw.plot_timeseries(DATA.Spd40mN, date_from='2017-09-01', date_to='2017-10-01', y_limits=(0, 25))
-    bw.plot_timeseries(DATA.Spd40mN, date_from='2017-09-01', date_to='2017-10-01', y_limits=(None, 25))
+    bw.plot_timeseries(DATA.Spd40mN, date_to='2017-10-01 00:00')
+    bw.plot_timeseries(DATA.Spd40mN, date_from='2017-09-01', date_to='2017-10-01 00:00', x_tick_label_angle=25)
+    bw.plot_timeseries(DATA.Spd40mN, date_from='2017-09-01', date_to='2017-10-01 00:00', y_limits=(0, None))
+    bw.plot_timeseries(DATA.Spd40mN, date_from='2017-09-01', date_to='2017-10-01 00:00', y_limits=None)
+    bw.plot_timeseries(DATA.Spd40mN, date_from='2017-09-01', date_to='2017-10-01 00:00', y_limits=(0, 25))
+    bw.plot_timeseries(DATA.Spd40mN, date_from='2017-09-01', date_to='2017-10-01 00:00', y_limits=(None, 25))
     bw.plot_timeseries(DATA[['Spd40mN', 'Spd60mS', 'T2m']], line_colors=['#009991', '#171a28', '#726e83'],
                        figure_size=(20, 4))
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -245,7 +245,8 @@ def test_offset_timestamps():
     assert op[1] == pd.to_datetime('2016-01-10 00:12:00')
 
     op = bw.offset_timestamps(series1.index, '2min', date_to='2016-01-10 00:30:00')
-    assert op[3] == pd.to_datetime('2016-01-10 00:32:00')
+    assert op[2] == pd.to_datetime('2016-01-10 00:22:00')
+    assert op[3] == pd.to_datetime('2016-01-10 00:30:00')
     assert op[4] == pd.to_datetime('2016-01-10 00:40:00')
 
     op = bw.offset_timestamps(series1.index, '3min', date_from='2016-01-10 00:10:00', date_to='2016-01-10 00:30:00')
@@ -271,9 +272,11 @@ def test_offset_timestamps():
     assert (op.loc['2016-01-10 00:40:00'] == series1.loc['2016-01-10 00:40:00']).all()
     assert len(op) + 1 == len(series1)
 
-    op = bw.offset_timestamps(series1, '10min', date_from='2016-01-10 00:10:00', date_to='2016-01-10 00:30:00',
+    op = bw.offset_timestamps(series1, '10min', date_from='2016-01-10 00:10:00', date_to='2016-01-10 00:40:00',
                               overwrite=True)
-    assert (op.loc['2016-01-10 00:40:00'] == series1.loc['2016-01-10 00:30:00']).all()
+    assert (op.loc['2016-01-10 00:20:00'] == series1.loc['2016-01-10 00:10:00']).all()
+    assert (op.loc['2016-01-10 00:30:00'] == series1.loc['2016-01-10 00:20:00']).all()
+    assert (op.loc['2016-01-10 00:50:00'] == series1.loc['2016-01-10 00:50:00']).all()
     assert len(op) + 1 == len(series1)
 
     # sending Series with datetime index
@@ -290,8 +293,9 @@ def test_offset_timestamps():
     assert (op.loc['2016-01-10 00:40:00'] == series1.Spd60mN.loc['2016-01-10 00:40:00']).all()
     assert len(op) + 1 == len(series1.Spd60mN)
 
-    op = bw.offset_timestamps(series1.Spd60mN, '10min', date_from='2016-01-10 00:10:00', date_to='2016-01-10 00:30:00',
+    op = bw.offset_timestamps(series1.Spd60mN, '10min', date_from='2016-01-10 00:10:00', date_to='2016-01-10 00:40:00',
                               overwrite=True)
+    assert (op.loc['2016-01-10 00:30:00'] == series1.Spd60mN.loc['2016-01-10 00:20:00']).all()
     assert (op.loc['2016-01-10 00:40:00'] == series1.Spd60mN.loc['2016-01-10 00:30:00']).all()
     assert len(op) + 1 == len(series1.Spd60mN)
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -295,6 +295,26 @@ def test_offset_timestamps():
     assert (op.loc['2016-01-10 00:40:00'] == series1.Spd60mN.loc['2016-01-10 00:30:00']).all()
     assert len(op) + 1 == len(series1.Spd60mN)
 
+    op = bw.offset_timestamps(series1.Spd60mN, '30min', date_from='2016-01-11', date_to='2016-01-12',
+                              overwrite=False)
+
+    assert (op.loc['2016-01-11 00:30:00'] == series1.Spd60mN.loc['2016-01-11 00:00:00']).all()
+    assert (op.loc['2016-01-11 23:50:00'] == series1.Spd60mN.loc['2016-01-11 23:20:00']).all()
+    assert (op.loc['2016-01-12 00:00:00'] == series1.Spd60mN.loc['2016-01-12 00:00:00']).all()
+
+    op = bw.offset_timestamps(series1.Spd60mN, '30min', date_from='2016-01-11', date_to='2016-01-12',
+                              overwrite=True)
+    assert (op.loc['2016-01-11 00:30:00'] == series1.Spd60mN.loc['2016-01-11 00:00:00']).all()
+    assert (op.loc['2016-01-11 23:50:00'] == series1.Spd60mN.loc['2016-01-11 23:20:00']).all()
+    assert (op.loc['2016-01-12 00:00:00'] == series1.Spd60mN.loc['2016-01-11 23:30:00']).all()
+    assert (op.loc['2016-01-12 00:30:00'] == series1.Spd60mN.loc['2016-01-12 00:30:00']).all()
+
+    assert bw.offset_timestamps(DATA.index[0], offset='4H') == pd.Timestamp('2016-01-09 19:30:00')
+    assert bw.offset_timestamps(datetime.datetime(2016, 2, 1, 0, 20), offset='3.5H'
+                                ) == datetime.datetime(2016, 2, 1, 3, 50)
+    assert bw.offset_timestamps(datetime.date(2016, 2, 1), offset='-5H') == datetime.datetime(2016, 1, 31, 19, 0)
+    assert bw.offset_timestamps(datetime.time(0, 20), offset='30min') == datetime.time(0, 50)
+
 
 def test_average_wdirs():
     wdirs = np.array([350, 10])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,23 @@
+import pytest
+import brightwind as bw
+import pandas as pd
+import numpy as np
+import matplotlib as mpl
+
+DATA = bw.load_csv(bw.demo_datasets.demo_data)
+DATA = bw.apply_cleaning(DATA, bw.demo_datasets.demo_cleaning_file)
+WSPD_COLS = ['Spd80mN', 'Spd80mS', 'Spd60mN', 'Spd60mS', 'Spd40mN', 'Spd40mS']
+WDIR_COLS = ['Dir78mS', 'Dir58mS', 'Dir38mS']
+
+
+def test_slice_data():
+    data_sliced = bw.utils.utils.slice_data(DATA, date_from='2016-11-23 00:30', date_to='2017-10-23 12:20')
+
+    assert data_sliced.index[0] == pd.Timestamp('2016-11-23 00:30')
+    assert data_sliced.index[-1] == pd.Timestamp('2017-10-23 12:20')
+
+    data_sliced = bw.utils.utils.slice_data(DATA, date_from='2016-11-23', date_to='2017-10-23')
+
+    assert data_sliced.index[0] == pd.Timestamp('2016-11-23 00:00')
+    assert data_sliced.index[-1] == pd.Timestamp('2017-10-22 23:50')
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,7 +12,7 @@ def test_slice_data():
     data_sliced = bw.utils.utils.slice_data(DATA, date_from='2016-11-23 00:30', date_to='2017-10-23 12:20')
 
     assert data_sliced.index[0] == pd.Timestamp('2016-11-23 00:30')
-    assert data_sliced.index[-1] == pd.Timestamp('2017-10-23 12:20')
+    assert data_sliced.index[-1] == pd.Timestamp('2017-10-23 12:10')
 
     data_sliced = bw.utils.utils.slice_data(DATA, date_from='2016-11-23', date_to='2017-10-23')
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,6 @@
 import pytest
 import brightwind as bw
 import pandas as pd
-import numpy as np
-import matplotlib as mpl
 
 DATA = bw.load_csv(bw.demo_datasets.demo_data)
 DATA = bw.apply_cleaning(DATA, bw.demo_datasets.demo_cleaning_file)
@@ -20,4 +18,10 @@ def test_slice_data():
 
     assert data_sliced.index[0] == pd.Timestamp('2016-11-23 00:00')
     assert data_sliced.index[-1] == pd.Timestamp('2017-10-22 23:50')
+
+    data_sliced = bw.utils.utils.slice_data(DATA, date_from='2016-11-23')
+    assert data_sliced.index[-1] == DATA.index[-1]
+
+    data_sliced = bw.utils.utils.slice_data(DATA, date_to='2017-10-23')
+    assert data_sliced.index[0] == DATA.index[0]
 


### PR DESCRIPTION
I have updated `slice_data`, `offset_timestamps`, `_LoadBWPlatform.get_data` functions to consider date_to input as not included. e.g if date_to = 2023-02-01 then sliced data, offsetted data and data we get from platform are considered up to 2023-01-31 23:50. This is consistent with method used for `bw.LoadBrightHub.get_data` and `load_cleaning_file`.

As part of this branch I have also:

1. updated the docstrings and tests of `slice_data`, `offset_timestamps`, `_LoadBWPlatform.get_data`. And also doctsrings of `momm`, `plot_timeseries` functions as using  `slice_data`.
2. fixed bugs below for `offset_timestamps`:
   - In docstring it is stated that function can accept a datetime.time input but an error was raised when using this. This is fixed now.
   - In docstring it is stated that the output of the function is in same format as the input, this was not the case for datetime.datetime and datetime.date inputs. This is fixed now.

