### PR TITLE
[Iss387] pandas version2 issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ _line_colors_, _legend_ and _figure_size_. (Issue #[349](https://github.com/brig
 19. Updated `_ColorPalette` to automatically update color_list, color_map, color_map_cyclical and adjusted lightness color variables when main colors (primary, secondary etc.) are changed. (Issue #[381](https://github.com/brightwind-dev/brightwind/issues/381)).
 19. Allow `momm` function to derive a seasonal adjusted mean of monthly mean, if user sets `seasonal_adjustment` to true, and allow to apply a `coverage_threshold` (Issue #[298](https://github.com/brightwind-dev/brightwind/issues/298))
 20. Updated `slice_data`, `offset_timestamps`, `_LoadBWPlatform.get_data` functions to use 'less than' data_to if provided as input. (Issue #[385](https://github.com/brightwind-dev/brightwind/issues/385))
-
+21. Update to work with Pandas 2.0.1, due to `date_format` input update for `pandas.to_datetime`. (Pull request #[387](https://github.com/brightwind-dev/brightwind/issues/387)).
 
 
 ## [2.0.0]

--- a/brightwind/load/load.py
+++ b/brightwind/load/load.py
@@ -1843,12 +1843,17 @@ def load_cleaning_file(filepath, date_from_col_name='Start', date_to_col_name='S
         print(cleaning_df)
 
     """
+    if pd.__version__ < '2.0.0':
+        date_format = None
+    else:
+        date_format = 'mixed'
+
     cleaning_df = _pandas_read_csv(filepath, **kwargs)
     # Issue when the date format is not the same in the full dataset.
     cleaning_df[date_from_col_name] = pd.to_datetime(cleaning_df[date_from_col_name],
-                                                     dayfirst=dayfirst).dt.tz_localize(None)
+                                                     dayfirst=dayfirst, format=date_format).dt.tz_localize(None)
     cleaning_df[date_to_col_name] = pd.to_datetime(cleaning_df[date_to_col_name],
-                                                   dayfirst=dayfirst).dt.tz_localize(None)
+                                                   dayfirst=dayfirst, format=date_format).dt.tz_localize(None)
     return cleaning_df
 
 

--- a/brightwind/utils/utils.py
+++ b/brightwind/utils/utils.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import datetime
 import os
 
 __all__ = ['slice_data',
@@ -60,20 +61,25 @@ def slice_data(data, date_from: str='', date_to: str=''):
     Returns the slice of data between the two date ranges,
     Date format: YYYY-MM-DD
     """
-    import datetime
-    date_from = pd.to_datetime(date_from, format="%Y-%m-%d")
-    date_to = pd.to_datetime(date_to, format="%Y-%m-%d")
+    if pd.__version__ < '2.0.0':
+        date_format = "%Y-%m-%d %H:%M"
+    else:
+        date_format = 'ISO8601'
 
     if pd.isnull(date_from):
         date_from = data.index[0]
+    else:
+        date_from = pd.to_datetime(date_from, format=date_format)
 
     if pd.isnull(date_to):
         date_to = data.index[-1]
+    else:
+        date_to = pd.to_datetime(date_to, format=date_format) - datetime.timedelta(seconds=1)
 
     if date_to < date_from:
         raise ValueError('date_to must be greater than date_from')
 
-    return data.loc[date_from:date_to, :]
+    return data.loc[date_from:date_to]
 
     # if (isinstance(date_from, datetime.date) or isinstance(date_from, datetime.datetime)) \
     #         and (isinstance(date_to, datetime.date) or isinstance(date_to, datetime.datetime)):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pandas          >= 0.24.0, <=1.5.3
+pandas          >= 0.24.0, <=2.0.1
 numpy           >= 1.16.4
 scikit-learn    >= 0.19.1
 matplotlib      >= 3.0.3

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     keywords=['BRIGHT', 'WIND', 'RESOURCE', 'DATA', 'ANALYSTS', 'PROCESSING', 'WASP', 'ROSE', 'WINDFARMER', 'OPENWIND',
               'WIND PRO', 'WINDOGRAPHER'],
     install_requires=[
-        'pandas>=0.24.0, <=1.5.3',
+        'pandas>=0.24.0, <=2.0.1',
         'numpy>=1.16.4',
         'scikit-learn>=0.19.1',
         'matplotlib>=3.0.3',
@@ -65,6 +65,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "License :: OSI Approved :: MIT License",
     ],
 )


### PR DESCRIPTION
Solved error generated with pandas >= 2.0.0 for `slice_data` and `load_cleaning_file` due to update made in pandas for `pd.to_datetime()`. Pandas > 2.0.0 doesn't automatically recognise the format if a correct format or format =“ISO8601” or format=
“mixed” input is not given to `pd.to_datetime()`, as explained at link below. https://pandas.pydata.org/docs/reference/api/pandas.to_datetime.html#pandas.to_datetime

Tests were performed using following libraries and versions (and lower versions).
Python 3.11.3
brightwind 2.1.0.dev0
matplotlib 3.7.1
numpy 1.24.3
pandas 2.0.1

NOTE: This issue needs to be merged to `dev` after #385, otherwise merging conflicts and errors are raised for the tests.