### PR TITLE
[iss #386] updated freq_table coverage filter to consider concurrent data

### DIFF
--- a/brightwind/analyse/analyse.py
+++ b/brightwind/analyse/analyse.py
@@ -1224,18 +1224,16 @@ def freq_table(var_series, direction_series, var_bin_array=np.arange(-0.5, 41, 1
     var_series = _convert_df_to_series(var_series).copy()
     direction_series = _convert_df_to_series(direction_series).copy()
 
-    # derive monthly coverage considering var_series, direction_series inputs
-    monthly_coverage = coverage(pd.concat([var_series.rename('var_data'), direction_series],
-                                          axis=1)).min(axis=1).replace(np.nan, 0.0)
+    data_concurrent = pd.concat([var_series, direction_series], axis=1).dropna()
 
-    var_series, text_msg_out = _filter_out_months_based_on_coverage_threshold(pd.concat([var_series, direction_series],
-                                                                                        axis=1)[var_series.name],
+    # derive monthly coverage considering var_series, direction_series inputs
+    monthly_coverage = coverage(data_concurrent)[var_series.name + '_Coverage']
+
+    var_series, text_msg_out = _filter_out_months_based_on_coverage_threshold(data_concurrent[var_series.name],
                                                                               monthly_coverage,
                                                                               coverage_threshold,
                                                                               analysis_type='frequency table',
                                                                               seasonal_adjustment=seasonal_adjustment)
-
-    data_concurrent = pd.concat([var_series, direction_series], axis=1).dropna()
 
     # If `target_freq_table_mean` is given as input to function then derive scale factor as ratio of
     # `target_freq_table_mean` and `data_concurrent` means.

--- a/tests/test_analyse.py
+++ b/tests/test_analyse.py
@@ -314,7 +314,7 @@ def test_freq_table():
 
     rose, freq_table = bw.freq_table(DATA.Spd40mN, DATA.Dir38mS, return_data=True, coverage_threshold=0.5,
                                      target_freq_table_mean=8)
-    assert round(bw.export.export._calc_mean_speed_of_freq_tab(freq_table), 3) == 8
+    assert round(bw.export.export._calc_mean_speed_of_freq_tab(freq_table), 2) == 8
 
 
 def test_dist():


### PR DESCRIPTION
@stephenholleran  as you requested I have updated freq_table function to use only concurrent data when filtering based on coverage. Up to you if you want to merge this change into dev.