### PR TITLE
Iss431 brighthub get reanalysis

### DIFF
--- a/brightwind/load/load.py
+++ b/brightwind/load/load.py
@@ -1416,7 +1416,8 @@ class LoadBrightHub:
         return df.set_index('Timestamp')
 
     @staticmethod
-    def get_reanalysis(reanalysis_name, latitude_ddeg, longitude_ddeg, date_from=None, date_to=None, variables=None):
+    def get_reanalysis(reanalysis_name, latitude_ddeg, longitude_ddeg, date_from=None, date_to=None, nearest_nodes=1,
+                       variables=None):
         """
         Get the reanalysis data from BrightHub for the n nearest nodes to a particular location. The IEA Task 43 WRA
         Daa Model and the timeseries for the reanlaysis data is retrieved.
@@ -1424,7 +1425,8 @@ class LoadBrightHub:
         When using the date filters, the brightwind convention for date ranges is greater than and equal to 'date_from'
         to less than 'date_to'.
 
-        Once the data model is retrieved you can use the brightwind MeasurementStation class to view and use the data from it.
+        Once the data model is retrieved you can use the brightwind MeasurementStation class to view and use the data 
+        from it.
 
         :param reanalysis_name:          The name of the reanalysis dataset. Allowed values: ERA5, MERRA-2.
         :type reanalysis_name:           str
@@ -1457,18 +1459,24 @@ class LoadBrightHub:
 
         To get all the data for the specific reanalysis node
         ::
-            metadata, timeseries = bw.LoadBrightHub.get_data(reanalysis_name='ERA5', latitude_ddeg=53.5, longtude_ddeg=-10.8)
+            metadata, timeseries = bw.LoadBrightHub.get_data(reanalysis_name='ERA5', 
+                                                             latitude_ddeg=53.5, 
+                                                             longtude_ddeg=-10.8)
             timeseries.head()
 
         To get data for a specific time period
         ::
-            metadata, timeseries = bw.LoadBrightHub.get_reanalysis_data(reanalysis_name='ERA5', latitude_ddeg=53.5, longtude_ddeg=-10.8,
+            metadata, timeseries = bw.LoadBrightHub.get_reanalysis_data(reanalysis_name='ERA5', 
+                                                                        latitude_ddeg=53.5, 
+                                                                        longtude_ddeg=-10.8,
                                                                         date_from='2016-06-01',
                                                                         date_to='2016-07-01')
 
         To get data from the nearest 4 nodes
         ::
-            metadata, timeseries = bw.LoadBrightHub.get_reanalysis_data(reanalysis_name='ERA5', latitude_ddeg=53.5, longtude_ddeg=-10.8,
+            metadata, timeseries = bw.LoadBrightHub.get_reanalysis_data(reanalysis_name='ERA5',
+                                                                        latitude_ddeg=53.5, 
+                                                                        longtude_ddeg=-10.8,
                                                                         nearest_nodes=4)
 
         Using the data model
@@ -1489,7 +1497,7 @@ class LoadBrightHub:
         # error handling
         if response.status_code == 400 and 'details' in response_json:  # request parameters invalid or missing
             raise ValueError(f"{response_json.get('error', '')}. {response_json.get('details', '')}")
-        if response.status_code == 403 and 'details' in response_json:  # insufficient permissions or download limit exceeded
+        if response.status_code == 403 and 'details' in response_json:  # insufficient permissions or download limit 
             raise ValueError(f"{response_json.get('error', '')}. {response_json.get('details', '')}")
         if response.status_code == 404 and 'details' in response_json:  # requested resource not found
             raise ValueError(f"{response_json.get('error', '')}. {response_json.get('details', '')}")
@@ -1498,7 +1506,8 @@ class LoadBrightHub:
         elif 'error' in response_json:
             raise ValueError(f"Unexpected error: Status Code {response.status_code}. {response.text}")
 
-        df = pd.DataFrame(response_json['timeseries_data']['data'], columns=response_json['timeseries_data']['columns'])
+        df = pd.DataFrame(response_json['timeseries_data']['data'], 
+                          columns=response_json['timeseries_data']['columns'])
         return response_json['metadata'], df.set_index('Timestamp')
 
 class _LoadBWPlatform:


### PR DESCRIPTION
Function to pull reanalysis data using the BrightHub api. The function accepts Merra-2/ERA5 data, coordinate information, date range parameters, and measurement variables.

Future functionality: pull the nearest n nodes to the input location. Currently the function only returns the nearest 1 node.