### PR TITLE
[iss 429] bug fix for Shear.TimeOfDay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Given a version number MAJOR.MINOR.PATCH, increment the:
 
 Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.
 
+## [2.2.1]
+1. Bug fix some users encounter with `plot.plot_shear_time_of_day()` (Issue [#429](https://github.com/brightwind-dev/brightwind/issues/429)).
+
 ## [2.2.0]
 1. Modify `Correl.OrdinaryLeastSquares()` to force the intercept to pass through the origin (Issue [#412](https://github.com/brightwind-dev/brightwind/issues/412)).
 1. Update `LoadBrightHub.get_data()` to use a new API (Issue [#419](https://github.com/brightwind-dev/brightwind/issues/419)).

--- a/brightwind/__init__.py
+++ b/brightwind/__init__.py
@@ -12,4 +12,4 @@ from .utils.gis import *
 
 __all__ = ['analyse', 'transform', 'export', 'load', 'demo_datasets']
 
-__version__ = '2.2.0'
+__version__ = '2.2.1'

--- a/brightwind/analyse/plot.py
+++ b/brightwind/analyse/plot.py
@@ -2145,7 +2145,7 @@ def plot_shear_time_of_day(df, calc_method, plot_type='step'):
         ax.set_ylabel(label)
 
         # create x values for plot
-        idx = pd.date_range('2017-01-01 00:00', '2017-01-01 23:00', freq='1H').time
+        idx = pd.date_range('2017-01-01 00:00', '2017-01-01 23:00', freq='1H').hour
 
         if plot_type == 'step':
             df = df.shift(+1, axis=0)
@@ -2158,7 +2158,7 @@ def plot_shear_time_of_day(df, calc_method, plot_type='step'):
                 ax.plot(idx, df.iloc[:, i], label=df.iloc[:, i].name, color=colors[i])
 
         ax.legend(bbox_to_anchor=(1.1, 1.05))
-        ax.set_xticks(df.index)
+        ax.set_xticks([ix.hour for ix in df.index])
         ax.xaxis.set_minor_formatter(mpl.dates.DateFormatter("%H-%M"))
         _ = plt.xticks(rotation=90)
         return ax.get_figure()

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     },
     url='https://github.com/brightwind-dev/brightwind.git',
     # UPDATE VERSION NUMBER HERE:
-    download_url='https://github.com/brightwind-dev/brightwind/archive/v2.2.0.tar.gz',
+    download_url='https://github.com/brightwind-dev/brightwind/archive/v2.2.1.tar.gz',
     license='MIT',
     author='Stephen Holleran of BrightWind Ltd',
     author_email='stephen@brightwindanalysis.com',


### PR DESCRIPTION
The `plot_shear_time_of_day` function in plot.py crashes **sometimes**. The real issue behind this fault is unclear - it looks to be a jupyter notebook issue. I think it's easier to update the `plot_shear_time_of_day` function to be more robust. The fix involves changing how the hour axis is is defined.