### PR TITLE
[Iss 443] Scatter plot label correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ Additional labels for pre-release and build metadata are available as extensions
 
 
 ## [2.X.0]
-1. Write new note here (Issue [#4xx](https://github.com/brightwind-dev/brightwind/issues/4xx)).
+1. Bug fix legend `scatter_plot_wspds` and `scatter_plot_wdirs` functions (Issue [#443](https://github.com/brightwind-dev/brightwind/issues/443)).
+2. Write new note here (Issue [#4xx](https://github.com/brightwind-dev/brightwind/issues/4xx)).
 
 
 ## [2.2.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Additional labels for pre-release and build metadata are available as extensions
 
 
 ## [2.X.0]
-1. Bug fix legend `scatter_plot_wspds` and `scatter_plot_wdirs` functions (Issue [#443](https://github.com/brightwind-dev/brightwind/issues/443)).
+1. Bug fix legend `plot_scatter_wspd` and `plot_scatter_wdir` functions and added tests (Issue [#443](https://github.com/brightwind-dev/brightwind/issues/443)).
 2. Write new note here (Issue [#4xx](https://github.com/brightwind-dev/brightwind/issues/4xx)).
 
 

--- a/brightwind/analyse/plot.py
+++ b/brightwind/analyse/plot.py
@@ -911,7 +911,6 @@ def plot_scatter_wdir(x_wdir_series, y_wdir_series, x_label=None, y_label=None,
     scat_plot = plot_scatter(x_wdir_series, y_wdir_series, x_label=x_label, y_label=y_label,
                              x_limits=x_limits, y_limits=y_limits, line_of_slope_1=True)
 
-    scat_plot.axes[0].legend(['Data points','1:1 line'])
     return scat_plot
 
 
@@ -963,7 +962,6 @@ def plot_scatter_wspd(x_wspd_series, y_wspd_series, x_label=None, y_label=None,
     scat_plot = plot_scatter(x_wspd_series, y_wspd_series, x_label=x_label, y_label=y_label,
                              x_limits=x_limits, y_limits=y_limits, line_of_slope_1=True)
 
-    scat_plot.axes[0].legend(['Data points','1:1 line'])
     return scat_plot
 
 

--- a/brightwind/analyse/plot.py
+++ b/brightwind/analyse/plot.py
@@ -911,7 +911,7 @@ def plot_scatter_wdir(x_wdir_series, y_wdir_series, x_label=None, y_label=None,
     scat_plot = plot_scatter(x_wdir_series, y_wdir_series, x_label=x_label, y_label=y_label,
                              x_limits=x_limits, y_limits=y_limits, line_of_slope_1=True)
 
-    scat_plot.axes[0].legend(['1:1 line', 'Data points'])
+    scat_plot.axes[0].legend(['Data points','1:1 line'])
     return scat_plot
 
 
@@ -963,7 +963,7 @@ def plot_scatter_wspd(x_wspd_series, y_wspd_series, x_label=None, y_label=None,
     scat_plot = plot_scatter(x_wspd_series, y_wspd_series, x_label=x_label, y_label=y_label,
                              x_limits=x_limits, y_limits=y_limits, line_of_slope_1=True)
 
-    scat_plot.axes[0].legend(['1:1 line', 'Data points'])
+    scat_plot.axes[0].legend(['Data points','1:1 line'])
     return scat_plot
 
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -64,18 +64,19 @@ def test_plot_scatter():
     assert plt_scatter.legend().get_texts()[0].get_text() == legend_first_text
     assert plt_scatter.legend().get_texts()[1].get_text() == legend_second_text
 
-    bw.plot_scatter_wdir(DATA.Dir78mS, DATA.Dir58mS, x_label='Reference', y_label='Target',
+    plt_scatter_wdir = bw.plot_scatter_wdir(DATA.Dir78mS, DATA.Dir58mS, x_label='Reference', y_label='Target',
                          x_limits=(50, 300), y_limits=(250, 300))
+    
+    assert plt_scatter_wdir.legend().get_texts()[0].get_text() == legend_first_text
+    assert plt_scatter_wdir.legend().get_texts()[1].get_text() == legend_second_text
+
     plt_scatter_wspd = bw.plot_scatter_wspd(DATA.Spd80mN, DATA.Spd80mS, x_label='Speed at 80m North',
                          y_label='Speed at 80m South', x_limits=(0, 25), y_limits=(0, 25))
     
     assert plt_scatter_wspd.legend().get_texts()[0].get_text() == legend_first_text
     assert plt_scatter_wspd.legend().get_texts()[1].get_text() == legend_second_text
     
-    plt_scatter_wdir = bw.plot_scatter_wspd(DATA.Spd80mN, DATA.Spd80mN, x_limits=(0, 25), y_limits=(0, 25))
-    
-    assert plt_scatter_wdir.legend().get_texts()[0].get_text() == legend_first_text
-    assert plt_scatter_wdir.legend().get_texts()[1].get_text() == legend_second_text
+    bw.plot_scatter_wspd(DATA.Spd80mN, DATA.Spd80mN, x_limits=(0, 25), y_limits=(0, 25))
 
     assert True
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -55,11 +55,27 @@ def test_plot_scatter():
     bw.plot_scatter(DATA.Spd80mN, DATA[['Spd80mS']])
     bw.plot_scatter(DATA.Dir78mS, DATA.Dir58mS, x_label='Dir78mS', y_label='Dir58mS',
                     x_limits=(50, 300), y_limits=(250, 300))
+    
+    plt_scatter = bw.plot_scatter(DATA.Dir78mS, DATA.Dir58mS, x_label='Dir78mS', y_label='Dir58mS',
+                    x_limits=(50, 300), y_limits=(250, 300), line_of_slope_1=True)
+    
+    legend_first_text = 'Data points'
+    legend_second_text = '1:1 line'
+    assert plt_scatter.legend().get_texts()[0].get_text() == legend_first_text
+    assert plt_scatter.legend().get_texts()[1].get_text() == legend_second_text
+
     bw.plot_scatter_wdir(DATA.Dir78mS, DATA.Dir58mS, x_label='Reference', y_label='Target',
                          x_limits=(50, 300), y_limits=(250, 300))
-    bw.plot_scatter_wspd(DATA.Spd80mN, DATA.Spd80mS, x_label='Speed at 80m North',
+    plt_scatter_wspd = bw.plot_scatter_wspd(DATA.Spd80mN, DATA.Spd80mS, x_label='Speed at 80m North',
                          y_label='Speed at 80m South', x_limits=(0, 25), y_limits=(0, 25))
-    bw.plot_scatter_wspd(DATA.Spd80mN, DATA.Spd80mN, x_limits=(0, 25), y_limits=(0, 25))
+    
+    assert plt_scatter_wspd.legend().get_texts()[0].get_text() == legend_first_text
+    assert plt_scatter_wspd.legend().get_texts()[1].get_text() == legend_second_text
+    
+    plt_scatter_wdir = bw.plot_scatter_wspd(DATA.Spd80mN, DATA.Spd80mN, x_limits=(0, 25), y_limits=(0, 25))
+    
+    assert plt_scatter_wdir.legend().get_texts()[0].get_text() == legend_first_text
+    assert plt_scatter_wdir.legend().get_texts()[1].get_text() == legend_second_text
 
     assert True
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -56,25 +56,30 @@ def test_plot_scatter():
     bw.plot_scatter(DATA.Dir78mS, DATA.Dir58mS, x_label='Dir78mS', y_label='Dir58mS',
                     x_limits=(50, 300), y_limits=(250, 300))
     
-    plt_scatter = bw.plot_scatter(DATA.Dir78mS, DATA.Dir58mS, x_label='Dir78mS', y_label='Dir58mS',
+    bw.plot_scatter(DATA.Dir78mS, DATA.Dir58mS, x_label='Dir78mS', y_label='Dir58mS',
                     x_limits=(50, 300), y_limits=(250, 300), line_of_slope_1=True)
     
-    legend_first_text = 'Data points'
-    legend_second_text = '1:1 line'
-    assert plt_scatter.legend().get_texts()[0].get_text() == legend_first_text
-    assert plt_scatter.legend().get_texts()[1].get_text() == legend_second_text
+    plt_scatter = bw.plot_scatter(DATA.Spd80mN, DATA.Spd80mS, trendline_y=[0, 15],trendline_x=[0, 10],
+                                  line_of_slope_1=True, x_label="Reference", y_label="Target")
+
+    legend_data_pnt_text = 'Data points'
+    legend_trendline_text = 'Regression line'
+    legend_line_text = '1:1 line'
+    assert plt_scatter.legend().get_texts()[0].get_text() == legend_data_pnt_text
+    assert plt_scatter.legend().get_texts()[1].get_text() == legend_trendline_text      
+    assert plt_scatter.legend().get_texts()[2].get_text() == legend_line_text
 
     plt_scatter_wdir = bw.plot_scatter_wdir(DATA.Dir78mS, DATA.Dir58mS, x_label='Reference', y_label='Target',
                          x_limits=(50, 300), y_limits=(250, 300))
     
-    assert plt_scatter_wdir.legend().get_texts()[0].get_text() == legend_first_text
-    assert plt_scatter_wdir.legend().get_texts()[1].get_text() == legend_second_text
+    assert plt_scatter_wdir.legend().get_texts()[0].get_text() == legend_data_pnt_text
+    assert plt_scatter_wdir.legend().get_texts()[1].get_text() == legend_line_text
 
     plt_scatter_wspd = bw.plot_scatter_wspd(DATA.Spd80mN, DATA.Spd80mS, x_label='Speed at 80m North',
                          y_label='Speed at 80m South', x_limits=(0, 25), y_limits=(0, 25))
     
-    assert plt_scatter_wspd.legend().get_texts()[0].get_text() == legend_first_text
-    assert plt_scatter_wspd.legend().get_texts()[1].get_text() == legend_second_text
+    assert plt_scatter_wspd.legend().get_texts()[0].get_text() == legend_data_pnt_text
+    assert plt_scatter_wspd.legend().get_texts()[1].get_text() == legend_line_text
     
     bw.plot_scatter_wspd(DATA.Spd80mN, DATA.Spd80mN, x_limits=(0, 25), y_limits=(0, 25))
 


### PR DESCRIPTION
The labels for 'data point' and '1:1 line' were mixed up for the `plot_scatter_wspds` and `plot_scatter_wdirs` now fixed.