### PR TITLE
iss #524 add mlp with eqm correlation

### DIFF
--- a/brightwind/analyse/correlation.py
+++ b/brightwind/analyse/correlation.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import re
 from typing import List
 from brightwind.transform import transform as tf
 from brightwind.analyse.plot import plot_scatter, plot_scatter_by_sector, plot_scatter_wdir
@@ -12,9 +13,31 @@ from brightwind.transform.transform import offset_wind_direction
 from brightwind.utils import utils
 import pprint
 import warnings
+from sklearn.neural_network import MLPRegressor
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import StandardScaler
+from cmethods import adjust
+import matplotlib.pyplot as plt
+import scipy
+
 
 __all__ = ['']
 
+
+def _get_radians(timestamps: pd.DatetimeIndex, period):
+    _NanosecondsInDay = 24 * 3600 * 10**9
+    _NanosecondsInYear = 365.2425 * _NanosecondsInDay
+    if period == 'day':
+        return 2 * np.pi * np.mod(timestamps.astype(np.int64) / _NanosecondsInDay, 1.0)
+    if period == 'year':
+        return 2 * np.pi * np.mod(timestamps.astype(np.int64) / _NanosecondsInYear, 1.0)
+
+
+def get_time_comps(data, period):
+    _NanosecondsInDay = 24 * 3600 * 10**9
+    _NanosecondsInYear = 365.2425 * _NanosecondsInDay
+    data_radians = _get_radians(data, period)
+    return np.cos(data_radians), np.sin(data_radians)
 
 class CorrelBase:
     def __init__(self, ref_spd, target_spd, averaging_prd, coverage_threshold=None, ref_dir=None, target_dir=None,
@@ -33,9 +56,11 @@ class CorrelBase:
         # Get the name of the columns so they can be passed around
         self._ref_spd_col_name = ref_spd.name if ref_spd is not None and isinstance(ref_spd, pd.Series) else None
         self._ref_spd_col_names = ref_spd.columns if ref_spd is not None and isinstance(ref_spd, pd.DataFrame) else None
-        self._ref_dir_col_name = ref_dir.name if ref_dir is not None else None
-        self._tar_spd_col_name = target_spd.name if target_spd is not None else None
-        self._tar_dir_col_name = target_dir.name if target_dir is not None else None
+        self._ref_dir_col_name = ref_dir.name if ref_dir is not None and isinstance(ref_dir, pd.Series) else None
+        self._tar_spd_col_name = target_spd.name if target_spd is not None and isinstance(target_spd, pd.Series) else None
+        self._tar_dir_col_name = target_dir.name if target_dir is not None and isinstance(target_dir, pd.Series) else None
+        self._tar_spd_col_names = target_spd.columns if target_spd is not None and isinstance(target_spd, pd.DataFrame) else None
+
 
         # Rename speed and direction reference column name(s) if any equal to target column name
         self.ref_spd, self._ref_spd_col_name, self._ref_spd_col_names, self.ref_dir, self._ref_dir_col_name = \
@@ -204,7 +229,13 @@ class CorrelBase:
                                                                                     self._tar_spd_col_name,
                                                                                     input1_suffix='_ref')
             self.ref_spd = self.ref_spd.rename(self._ref_spd_col_name)
-        elif isinstance(self.ref_spd, pd.DataFrame) and self._ref_spd_col_names is not None:
+        elif isinstance(self.ref_spd, pd.DataFrame) and isinstance(self.target_spd, pd.DataFrame) and self._ref_spd_col_names is not None:
+            self._ref_spd_col_names = self._rename_equal_elements_between_two_inputs(list(self._ref_spd_col_names),
+                                                                                     list(self._tar_spd_col_names),
+                                                                                     input1_suffix='_ref')
+            self.ref_spd.columns = self._ref_spd_col_names
+            
+        elif isinstance(self.ref_spd, pd.DataFrame) and isinstance(self.target_spd, pd.Series) and self._ref_spd_col_names is not None:
             self._ref_spd_col_names = self._rename_equal_elements_between_two_inputs(list(self._ref_spd_col_names),
                                                                                      self._tar_spd_col_name,
                                                                                      input1_suffix='_ref')
@@ -220,8 +251,8 @@ class CorrelBase:
         return self.ref_spd, self._ref_spd_col_name, self._ref_spd_col_names, self.ref_dir, self._ref_dir_col_name
 
     def _get_synth_start_dates(self):
-        none_even_freq = ['5H', '7H', '9H', '10H', '11H', '13H', '14H', '15H', '16H', '17H', '18H', '19H',
-                          '20H', '21H', '22H', '23H', 'D', 'W']
+        none_even_freq = ['5h', '7h', '9h', '10h', '11h', '13h', '14h', '15h', '16h', '17h', '18h', '19h',
+                          '20h', '21h', '22h', '23h', 'D', 'W']
         if any(freq in self.averaging_prd for freq in none_even_freq):
             ref_time_array = pd.date_range(start=self.data.index[0], freq='-' + self.averaging_prd,
                                            end=self.ref_spd.index[0])
@@ -302,6 +333,8 @@ class CorrelBase:
 
         if isinstance(output, pd.Series):
             return output.to_frame(name=self.target_spd.name + "_Synthesized")
+        elif isinstance(output, pd.DataFrame):
+            return output.add_suffix("_Synthesized")
         else:
             output.columns = [self.target_spd.name + "_Synthesized"]
             return output
@@ -323,7 +356,7 @@ class OrdinaryLeastSquares(CorrelBase):
     :param averaging_prd:             Groups data by the time period specified here. The following formats are supported
 
             - Set period to '10min' for 10 minute average, '30min' for 30 minute average.
-            - Set period to '1H' for hourly average, '3H' for three hourly average and so on for '4H', '6H' etc.
+            - Set period to '1h' for hourly average, '3h' for three hourly average and so on for '4h', '6h' etc.
             - Set period to '1D' for a daily average, '3D' for three day average, similarly '5D', '7D', '15D' etc.
             - Set period to '1W' for a weekly average, '3W' for three week average, similarly '2W', '4W' etc.
             - Set period to '1M' for monthly average with the timestamp at the start of the month.
@@ -405,7 +438,7 @@ class OrdinaryLeastSquares(CorrelBase):
 
         # Correlate temperature on an hourly basis using a different aggregation method.
         ols_cor = bw.Correl.OrdinaryLeastSquares(m2_ne['T2M_degC'], data['T2m'],
-                                                 averaging_prd='1H', coverage_threshold=0,
+                                                 averaging_prd='1h', coverage_threshold=0,
                                                  ref_aggregation_method='min', target_aggregation_method='min')
 
         # Correlate wind speeds on a monthly basis and force the intercept through the origin.
@@ -419,7 +452,7 @@ class OrdinaryLeastSquares(CorrelBase):
 
         # Correlate by directional sector forcing the intercept through the origin.
         ols_cor = bw.Correl.OrdinaryLeastSquares(m2_ne['WS50m_m/s'], data['Spd80mN'],
-                                                 ref_dir=m2_ne['WD50m_deg'], averaging_prd='1H',
+                                                 ref_dir=m2_ne['WD50m_deg'], averaging_prd='1h',
                                                  coverage_threshold=0.9, forced_intercept_origin=True)
     """
     def __init__(self, ref_spd, target_spd, averaging_prd, coverage_threshold=0.9, ref_dir=None, sectors=12,
@@ -462,7 +495,7 @@ class OrdinaryLeastSquares(CorrelBase):
         elif type(self.ref_dir) is pd.Series:
             self.params = []
             for sector, group in pd.concat([self.data, self._ref_dir_bins],
-                                           axis=1, join='inner').dropna().groupby('ref_dir_bin'):
+                                           axis=1, join='inner').dropna().groupby('ref_dir_bin', observed=False):
                 # print('Processing sector:', sector)
                 if len(group) > 1:
                     slope, offset = self._leastsquare(ref_spd=group[self._ref_spd_col_name],
@@ -501,6 +534,293 @@ class OrdinaryLeastSquares(CorrelBase):
         return ref_spd * slope + offset
 
 
+class MultiLayerPerceptron(CorrelBase):
+    """
+    Correlate two datasets against each other using a Multi Layer Perceptron neural network combined with Empirical Quantile Mapping (EQM). 
+    This accepts two dataframes as inputs each one must have wind speed and wind direction other parameters are optional, but 
+    temperature and pressure are recommended to be used for X as well.
+    An averaging period which merges the datasets by this time period should be added also, however 
+    note that using averaging larger than 1h is not recommended,  before performing the correlation.
+
+    The methodology (especially the EQM step) is inspired from Vortex Remodelling technique, but is more 
+    limited and is currently only tested one one site - proper validation is required:
+    https://vortexfdc.com/resources/vortex-times-remodeling-methodology-validation/
+
+    The EQM is done using the python-cmethods package:
+    Benjamin T. Schwertfeger. (2025). btschwertfeger/python-cmethods: v2.3.1 (v2.3.1). 
+    Zenodo. https://doi.org/10.5281/zenodo.15128642
+
+    :param ref_spd:                   Series containing reference wind speed and direction as columns (optionally more columns can be passed to be used for the correlation), timestamp as the index.
+    :type ref_spd:                    pd.DataFrame
+    :param target_spd:                Series containing target wind speed and wind direction as columns, timestamp as the index.
+    :type target_spd:                 pd.DataFrame
+    :param averaging_prd:             Groups data by the time period specified here. The following formats are supported
+
+            - Set period to '10min' for 10 minute average, '30min' for 30 minute average.
+            - Set period to '1h' for hourly average
+
+    :type averaging_prd:              str
+    :param ref_spd_col:               name of the reference wind speed column
+    :type ref_spd_col:                str
+    :param tar_spd_col:               name of the target wind speed column
+    :type tar_spd_col:                str
+    :param ref_dir_col:               name of the reference wind direction column
+    :type ref_dir_col:                str
+    :param tar_dir_col:               name of the target wind direction column
+    :type tar_dir_col:                str
+    :param ref_aggregation_method:    Default `mean`, returns the mean of the data for the specified period. Can also
+                                      use `median`, `prod`, `sum`, `std`,`var`, `max`, `min` which are shorthands for
+                                      median, product, summation, standard deviation, variance, maximum and minimum
+                                      respectively.
+    :type ref_aggregation_method:     str
+    :param target_aggregation_method: Default `mean`, returns the mean of the data for the specified period. Can also
+                                      use `median`, `prod`, `sum`, `std`,`var`, `max`, `min` which are shorthands for
+                                      median, product, summation, standard deviation, variance, maximum and minimum
+                                      respectively.
+    :type target_aggregation_method:  str
+    :param loss:                      The loss function of the MLPRegressor to use when training the weights. See sklearn MLPRegressor documentation for more details.
+    :type loss:                       str
+    :param hidden_layer_sizes:        The ith element of the MLPRegressor represents the number of neurons in the ith hidden layer. See sklearn MLPRegressor documentation for more details.
+    :type hidden_layer_sizes:         tuple
+    :param activation:                Activation function of the MLPRegressor for the hidden layer. See sklearn MLPRegressor documentation for more details.
+    :type activation:                 str
+    :param solver:                    The solver of the MLPRegressor for weight optimization. See sklearn MLPRegressor documentation for more details.
+    :type solver:                     str
+    :param alpha:                     Strength of the L2 regularization term for the MLPRegressor. See sklearn MLPRegressor documentation for more details.
+    :type alpha:                      float
+    :param max_iter:                  Maximum number of iteration of the MLPRegressor. See sklearn MLPRegressor documentation for more details.
+    :type max_iter:                   int
+    :param random_state:              Determines random number generation for weights and bias initialization of the MLPRegressor. See sklearn MLPRegressor documentation for more details.
+    :type random_state:               int
+
+    :returns:                         An object representing the multi layer perceptron with empirical quantile mapping fit model
+
+    **Example usage**
+    ::
+        import brightwind as bw
+        data = bw.load_csv(bw.demo_datasets.demo_data)
+        m2_ne = bw.load_csv(bw.demo_datasets.demo_merra2_NE)
+
+        # Correlate wind speeds on a monthly basis.
+        mlp = bw.Correl.MultiLayerPerceptron(m2_ne[[v_wsnode,v_wdnode, v_tnode, v_pnode]].dropna(), 
+                                     data[[o_wsnode, o_wdnode]].dropna(),
+                                     alpha=1,
+                                     ref_spd_col=v_wsnode,
+                                     tar_spd_col=o_wsnode,
+                                     ref_dir_col=v_wdnode,
+                                     tar_dir_col=o_wdnode,
+                                     averaging_prd='1h'
+                                     )
+        mlp.run()
+
+        # To plot the scatter plot of target vs reference wind speed, for training and predicted periods 
+        mlp.plot()
+
+        # To change the plot's size.
+        mlp.plot(figure_size=(12,15))
+
+        # To show the model parameters.
+        mlp.params
+        # or
+        mlp.show_params()
+
+        # To synthesize data at the target site - ext_input is recommended to be passed as below to not splice data for the training period
+        mlp.synthesize(ext_input=mlp.ref_spd[mlp._ref_spd_fit_col_names])
+
+        # To retrieve the merged and aggregated data used in the correlation.
+        mlp.data
+
+        # To retrieve the number of data points used for the correlation
+        mlp.num_data_pts
+
+        # To retrieve the input parameters.
+        mlp.averaging_prd
+        mlp.ref_spd
+        mlp.ref_aggregation_method
+        mlp.target_spd
+        mlp.target_aggregation_method
+
+    """
+    def __init__(self, ref_spd, target_spd, averaging_prd, 
+                 ref_spd_col, tar_spd_col, ref_dir_col, tar_dir_col, 
+                 ref_aggregation_method='mean', target_aggregation_method='mean',
+                 loss='squared_error', hidden_layer_sizes=(100,), activation='relu', solver='adam', alpha=1E-0, max_iter=1000,
+                 random_state=None
+                 ):
+
+        self.loss=loss
+        self.hidden_layer_sizes=hidden_layer_sizes
+        self.activation=activation
+        self.solver=solver
+        self.alpha=alpha
+        self.max_iter=max_iter
+        self.random_state=random_state
+        self.ref_spd, self.target_spd = self.prepare(ref_spd, target_spd, ref_spd_col, ref_dir_col, tar_spd_col, tar_dir_col)
+
+        CorrelBase.__init__(self, ref_spd, target_spd, averaging_prd, 
+                            ref_aggregation_method=ref_aggregation_method,
+                            target_aggregation_method=target_aggregation_method
+                            )
+        
+        self._ref_spd_col_name =ref_spd_col
+        self._ref_dir_col_name =ref_dir_col
+        self._tar_dir_col_name =tar_dir_col
+        self._tar_spd_col_name =tar_spd_col
+        self._ref_spd_fit_col_names = list(self._ref_spd_col_names.copy()) #first we copy the list so we can edit without causing issues
+        self._ref_spd_fit_col_names.remove(self._ref_spd_col_name)
+        self._ref_spd_fit_col_names.remove(self._ref_dir_col_name)
+        self._tar_spd_fit_col_names = list(self._tar_spd_col_names.copy()) #first we copy the list so we can edit without causing issues
+        self._tar_spd_fit_col_names.remove(self._tar_spd_col_name)
+        self._tar_spd_fit_col_names.remove(self._tar_dir_col_name)
+
+        self.model_ = None  # will hold the fitted pipeline
+
+        #check if time resolution larger than hours
+        if isinstance(averaging_prd, str):
+            strlist = re.split('(\\d+)', averaging_prd)
+            if strlist[-1] not in ['min', 'h', 'H']:
+                print("The averaging_prd is greater than hours, which is not recommended for the MLP method. Consider updating it to 10min or 1h.")
+
+    def __repr__(self):
+        return 'Multi-layer Perceptron ' + str(self.params)
+    
+    def prepare(self, ref_spd, target_spd, ref_spd_col, ref_dir_col, tar_spd_col, tar_dir_col):
+        #prepare ref_spd data        
+        #go from polar to cartesian
+        ref_spd['cos_u'] = np.cos(np.deg2rad(ref_spd[ref_dir_col])) * ref_spd[ref_spd_col]
+        ref_spd['sin_u'] = np.sin(np.deg2rad(ref_spd[ref_dir_col])) * ref_spd[ref_spd_col]
+        #then conver hour and month to polar domain, to facilitate ML training (as months and hours are cyclical)
+        year_cos, year_sin = get_time_comps(ref_spd.index, 'year')
+        ref_spd['time_of_year_cos'] = year_cos
+        ref_spd['time_of_year_sin'] = year_sin
+        day_cos, day_sin = get_time_comps(ref_spd.index, 'day')
+        ref_spd['time_of_day_cos'] = day_cos
+        ref_spd['time_of_day_sin'] = day_sin
+
+        #prepare target_spd data 
+        target_spd['o_cos_u'] =  np.cos(np.deg2rad(target_spd[tar_dir_col])) * target_spd[tar_spd_col]
+        target_spd['o_sin_u'] =  np.sin(np.deg2rad(target_spd[tar_dir_col])) * target_spd[tar_spd_col]
+        return ref_spd, target_spd
+
+            
+    def model(self):
+        #we pass a pipeline and use StandardScaler to scale the inputs, as recomended by MLPRegressor doc
+        return make_pipeline(
+            StandardScaler(),
+            MLPRegressor(
+                loss=self.loss,
+                hidden_layer_sizes=self.hidden_layer_sizes,
+                activation=self.activation,
+                solver=self.solver,
+                alpha=self.alpha,
+                max_iter=self.max_iter,
+                random_state=self.random_state #for testing and reproducibility purposes
+                ),
+                )
+
+    def run(self):
+        if self.model_ is None:
+            self.model_ = self.model()
+        self.model_.fit(self.data[self._ref_spd_fit_col_names], self.data[self._tar_spd_fit_col_names])
+
+        self.params = self.model_.get_params()
+        self.score = self.model_.score(self.data[self._ref_spd_fit_col_names], self.data[self._tar_spd_fit_col_names])
+
+    def _predict(self, ref_spd):
+        if self.model_ is None:
+            raise RuntimeError("Model is not fitted. Call run() first.")
+
+        #post processing
+        predicted = pd.DataFrame(data=self.model_.predict(ref_spd), index=self.ref_spd.index, columns=['o_cos_u_Synthesized', 'o_sin_u_Synthesized'])
+        predicted[self._tar_spd_col_name] = np.sqrt(predicted['o_cos_u_Synthesized']**2 + predicted['o_sin_u_Synthesized']**2)
+        predicted[self._tar_dir_col_name] = np.mod(np.rad2deg(np.arctan2(predicted['o_sin_u_Synthesized'], predicted['o_cos_u_Synthesized'])),360)
+        
+        self.predicted = predicted[[self._tar_spd_col_name, self._tar_dir_col_name]]
+
+        predicted_eqm_ws = self.eqm(variable="Wind Speed")
+        predicted_eqm_wd = self.eqm(variable="Wind Direction")
+        predicted_eqm = predicted_eqm_ws.merge(predicted_eqm_wd, left_index=True, right_index=True)
+        return predicted_eqm
+    
+    def plot(self, figure_size=(18, 10)):
+        fig, axes = plt.subplots(1, 2, figsize=figure_size)
+        slope1, intercept1, r_value1, p_value1, std_err1 = scipy.stats.linregress(self.data[self._ref_spd_col_name], self.data[self._tar_spd_col_name])
+        r2_1 = r_value1**2
+
+        plot_scatter(self.data[self._ref_spd_col_name],
+                     self.data[self._tar_spd_col_name],
+                     slope1*self.data[self._ref_spd_col_name] + intercept1,
+                     x_label=self._ref_spd_col_name + ' (training)', y_label=self._tar_spd_col_name + ' (training)',
+                     line_of_slope_1=False, figure_size=figure_size, ax=axes[0], trendline_name= 'Linear trendline (linear R²={})'.format(round(r2_1,2)))
+        
+        #we merge both measurements and predicted data to align coverage and have no nans
+        merged_data = self.data[[self._tar_spd_col_name]].merge(self.predicted[[self._tar_spd_col_name]], left_index=True, right_index=True,suffixes=(' (Measured)', ' (Predicted)'))
+
+        slope2, intercept2, r_value2, p_value2, std_err2 = scipy.stats.linregress(merged_data[self._tar_spd_col_name+' (Measured)'], merged_data[self._tar_spd_col_name+' (Predicted)'])
+        r2_2 = r_value2**2
+
+        plot_scatter(merged_data[self._tar_spd_col_name+' (Measured)'],
+                     merged_data[self._tar_spd_col_name+' (Predicted)'],
+                     slope2*merged_data[self._tar_spd_col_name+' (Measured)'] + intercept2,
+                     x_label=self._tar_spd_col_name + ' (Measured)', y_label=self._tar_spd_col_name + ' (Predicted)',
+                     line_of_slope_1=False, figure_size=figure_size, ax=axes[1], trendline_name= 'Linear trendline (linear R²={})'.format(round(r2_2,2)))
+        return fig
+
+    def eqm(self, variable="Wind Speed"):
+        #obsh = observation for the historical period
+        #simh = simulation for the historical period
+        #simp = observation for the future period
+
+        #format inputs
+        if variable == "Wind Speed":
+            variable_col = self._tar_spd_col_name
+        elif variable == "Wind Direction":
+            variable_col = self._tar_dir_col_name
+        else:
+            print("Error - variables can only be 'Wind Speed' or 'Wind Direction'")
+
+        obsh_df = self.data[[variable_col]]
+        obsh_df.index.names = ['time1']
+        if obsh_df.index.tz:
+            obsh_df.index = obsh_df.index.tz_localize(None)
+        obsh = obsh_df.to_xarray()
+
+        #we define the start and end of "historical" period
+        start_h = self.data[[variable_col]].index.min()
+        end_h  = self.data[[variable_col]].index.max()
+
+        simh_df = self.predicted.loc[start_h:end_h,[variable_col]] #for historical period only
+        simh_df.index.names = ['time2']
+        if simh_df.index.tz:
+            simh_df.index = simh_df.index.tz_localize(None)
+        simh = simh_df.to_xarray()
+
+        simp_df = self.predicted[[variable_col]] #for whole period
+        simp_df.index.names = ['time3']
+        if simp_df.index.tz:
+            sim_tz = str(simp_df.index.tz)
+            simp_df.index = simp_df.index.tz_localize(None)
+        else:
+            sim_tz = None
+        simp = simp_df.to_xarray()
+
+        predicted_eqm = adjust(method="quantile_mapping",
+                               obs=obsh[variable_col],
+                               simh=simh[variable_col],
+                               simp=simp[variable_col],
+                               input_core_dims={"obs": "time1", "simh": "time2", "simp": "time3"},
+                               n_quantiles=60,
+                               kind="+"
+                               ).to_dataframe()
+
+        #postprocessing back to normal
+        predicted_eqm.index = predicted_eqm.index.tz_localize(sim_tz)
+        predicted_eqm.index.name = self.data.index.name
+        
+        return predicted_eqm
+
+
+
 class OrthogonalLeastSquares(CorrelBase):
     """
     Correlate two datasets against each other using the Orthogonal Least Squares method. This accepts two wind speed
@@ -514,7 +834,7 @@ class OrthogonalLeastSquares(CorrelBase):
     :param averaging_prd:             Groups data by the time period specified here. The following formats are supported
 
             - Set period to '10min' for 10 minute average, '30min' for 30 minute average.
-            - Set period to '1H' for hourly average, '3H' for three hourly average and so on for '4H', '6H' etc.
+            - Set period to '1h' for hourly average, '3h' for three hourly average and so on for '4h', '6h' etc.
             - Set period to '1D' for a daily average, '3D' for three day average, similarly '5D', '7D', '15D' etc.
             - Set period to '1W' for a weekly average, '3W' for three week average, similarly '2W', '4W' etc.
             - Set period to '1M' for monthly average with the timestamp at the start of the month.
@@ -583,7 +903,7 @@ class OrthogonalLeastSquares(CorrelBase):
 
         # Correlate temperature on an hourly basis using a different aggregation method.
         orthog_cor = bw.Correl.OrthogonalLeastSquares(m2_ne['T2M_degC'], data['T2m'],
-                                                      averaging_prd='1H', coverage_threshold=0,
+                                                      averaging_prd='1h', coverage_threshold=0,
                                                       ref_aggregation_method='min', target_aggregation_method='min')
 
     """
@@ -638,7 +958,7 @@ class MultipleLinearRegression(CorrelBase):
     :param averaging_prd:             Groups data by the time period specified here. The following formats are supported
 
             - Set period to '10min' for 10 minute average, '30min' for 30 minute average.
-            - Set period to '1H' for hourly average, '3H' for three hourly average and so on for '4H', '6H' etc.
+            - Set period to '1h' for hourly average, '3h' for three hourly average and so on for '4h', '6h' etc.
             - Set period to '1D' for a daily average, '3D' for three day average, similarly '5D', '7D', '15D' etc.
             - Set period to '1W' for a weekly average, '3W' for three week average, similarly '2W', '4W' etc.
             - Set period to '1M' for monthly average with the timestamp at the start of the month.
@@ -705,7 +1025,7 @@ class MultipleLinearRegression(CorrelBase):
 
         # Correlate temperature on an hourly basis using a different aggregation method.
         mul_cor = bw.Correl.MultipleLinearRegression([m2_ne['T2M_degC'], m2_nw['T2M_degC']], data['T2m'],
-                                                     averaging_prd='1H', coverage_threshold=0,
+                                                     averaging_prd='1h', coverage_threshold=0,
                                                      ref_aggregation_method='min', target_aggregation_method='min')
 
     """
@@ -905,7 +1225,7 @@ class SpeedSort(CorrelBase):
         :param averaging_prd:       Groups data by the time period specified here. The following formats are supported
 
                 - Set period to '10min' for 10 minute average, '30min' for 30 minute average.
-                - Set period to '1H' for hourly average, '3H' for three hourly average and so on for '4H', '6H' etc.
+                - Set period to '1h' for hourly average, '3h' for three hourly average and so on for '4h', '6h' etc.
                 - Set period to '1D' for a daily average, '3D' for three day average, similarly '5D', '7D', '15D' etc.
                 - Set period to '1W' for a weekly average, '3W' for three week average, similarly '2W', '4W' etc.
                 - Set period to '1M' for monthly average with the timestamp at the start of the month.
@@ -936,7 +1256,7 @@ class SpeedSort(CorrelBase):
 
             # Basic usage on an hourly basis
             ss_cor = bw.Correl.SpeedSort(m2['WS50m_m/s'], m2['WD50m_deg'], data['Spd80mN'], data['Dir78mS'],
-                                         averaging_prd='1H')
+                                         averaging_prd='1h')
             ss_cor.run()
             ss_cor.plot_wind_directions()
             ss_cor.get_result_table()
@@ -944,7 +1264,7 @@ class SpeedSort(CorrelBase):
 
             # Sending an array of direction sectors
             ss_cor = bw.Correl.SpeedSort(m2['WS50m_m/s'], m2['WD50m_deg'], data['Spd80mN'], data['Dir78mS'],
-                                         averaging_prd='1H', direction_bin_array=[0,90,130,200,360])
+                                         averaging_prd='1h', direction_bin_array=[0,90,130,200,360])
             ss_cor.run()
 
         """
@@ -1018,7 +1338,7 @@ class SpeedSort(CorrelBase):
         self.params['target_veer_cutoff'] = round(self.target_veer_cutoff, 5)
         self.params['overall_average_veer'] = round(self.overall_veer, 5)
         for sector, group in pd.concat([self.data, self._ref_dir_bins],
-                                       axis=1, join='inner').dropna().groupby('ref_dir_bin'):
+                                       axis=1, join='inner').dropna().groupby('ref_dir_bin', observed=False):
             # print('Processing sector:', sector)
             self.speed_model[sector] = SpeedSort.SectorSpeedModel(ref_spd=group[self._ref_spd_col_name],
                                                                   target_spd=group[self._tar_spd_col_name],
@@ -1210,7 +1530,7 @@ class SpeedSort(CorrelBase):
                                                 direction_bin_array=self.direction_bin_array).rename('ref_dir_bin')],
                       axis=1, join='inner').dropna()
         prediction = pd.Series(dtype='float64').rename('spd')
-        for sector, data in x.groupby('ref_dir_bin'):
+        for sector, data in x.groupby('ref_dir_bin', observed=False):
             if sector in list(self.speed_model.keys()):
                 prediction_spd = self.speed_model[sector].sector_predict(data['spd'])
             else:

--- a/brightwind/analyse/plot.py
+++ b/brightwind/analyse/plot.py
@@ -972,7 +972,7 @@ def _get_best_row_col_number_for_subplot(number_subplots):
 
 def plot_scatter(x, y, trendline_y=None, trendline_x=None, line_of_slope_1=False,
                  x_label=None, y_label=None, x_limits=None, y_limits=None, axes_equal=True, figure_size=(10, 10.2),
-                 trendline_dots=False, **kwargs):
+                 trendline_dots=False, ax=None, trendline_name=None, **kwargs):
     """
     Plots a scatter plot of x and y data. The trendline_y data is also shown if provided as input of the function.
 
@@ -1064,10 +1064,15 @@ def plot_scatter(x, y, trendline_y=None, trendline_x=None, line_of_slope_1=False
     if line_of_slope_1 is True:
         legend = True
 
-    fig, axes = plt.subplots(figsize=figure_size, **kwargs)
+    # Create a new fig/ax only if none was passed
+    if ax is None:
+        fig, ax = plt.subplots(figsize=figure_size, **kwargs)
+    else:
+        fig = ax.figure  # Get the figure from the passed axes
+
     _scatter_subplot(x, y, trendline_y=trendline_y, trendline_x=trendline_x, line_of_slope_1=line_of_slope_1,
                      x_label=x_label, y_label=y_label, x_limits=x_limits, y_limits=y_limits, axes_equal=axes_equal,
-                     trendline_dots=trendline_dots, legend=legend, ax=axes)
+                     trendline_dots=trendline_dots, legend=legend, ax=ax, trendline_name=trendline_name)
 
     plt.close()
     return fig
@@ -1971,7 +1976,7 @@ def plot_shear_by_sector(scale_variable, wind_rose_data, calc_method='power_law'
     if calc_method == 'log_law':
         label = 'Mean_Roughness_Coefficient'
 
-    scale_variable_y = np.append(scale_variable, scale_variable[0])
+    scale_variable_y = np.append(scale_variable, scale_variable.iloc[0])
     plot_x = np.append(radians, radians[0])
     scale_to_fit = max(scale_variable[np.isfinite(scale_variable)]) / max(result / 100)
     wind_rose_r = (result / 100) * scale_to_fit
@@ -2352,7 +2357,7 @@ def plot_shear_time_of_day(df, calc_method, plot_type='step'):
         ax.set_ylabel(label)
 
         # create x values for plot
-        idx = pd.date_range('2017-01-01 00:00', '2017-01-01 23:00', freq='1H').hour
+        idx = pd.date_range('2017-01-01 00:00', '2017-01-01 23:00', freq='1h').hour
 
         if plot_type == 'step':
             df = df.shift(+1, axis=0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ colormap        >= 1.0.1
 easydev         >= 0.10.0
 jsonschema      >= 4.17.3
 jinja2          >= 3.0.0
+python-cmethods >= 2.3.1

--- a/tests/test_correlation.py
+++ b/tests/test_correlation.py
@@ -277,7 +277,7 @@ def test_synthesize():
 
     for idx, row in pd.DataFrame(result_ord_lst_sq).iterrows():
         # Comparing the first 6 digits to avoid issuing with floating point precision
-        assert str(row[0])[0:6] == str(synth.loc[idx][0])[0:6]
+        assert str(row.iloc[0])[0:6] == str(synth.loc[idx].iloc[0])[0:6]
 
     # Test the synthesise for when the ref_dir is given as input.
     correl = bw.Correl.OrdinaryLeastSquares(MERRA2_NE['WS50m_m/s']['2016-03-02 00:00:00':],
@@ -288,7 +288,7 @@ def test_synthesize():
     synth = correl.synthesize()
 
     for idx, row in pd.DataFrame(result_ord_lst_sq_dir).iterrows():
-        assert str(row[0]) == str(round(synth.loc[idx][0], 6))
+        assert str(row.iloc[0]) == str(round(synth.loc[idx].iloc[0], 6))
 
     # Test the synthesise when SpeedSort correlation is used.
     correl = bw.Correl.SpeedSort(MERRA2_NE['WS50m_m/s']['2016-03-02 00:00:00':'2017-03-02 00:00:00'],
@@ -301,14 +301,14 @@ def test_synthesize():
 
     for idx, row in pd.DataFrame(result_speed_sort).iterrows():
         print(idx)
-        assert str(row[0]) == str(round(synth.loc[idx][0], 6))
+        assert str(row.iloc[0]) == str(round(synth.loc[idx].iloc[0], 6))
 
     # Test the synthesise when SpeedSort correlation is used using 10 min averaging period.
     data_test = DATA_CLND[['Spd80mN', 'Spd60mN', 'Dir78mS', 'Dir58mS']].copy()
-    data_test['Dir78mS']['2016-01-09 17:10:00':'2016-01-09 17:50:00'] = np.nan
-    data_test['Spd80mN']['2016-01-09 17:10:00':'2016-01-09 17:50:00'] = np.nan
-    data_test['Dir58mS']['2016-01-09 17:50:00':'2016-01-10 19:10:00'] = np.nan
-    data_test['Spd60mN']['2016-01-09 17:50:00':'2016-01-10 19:10:00'] = np.nan
+    data_test.loc['2016-01-09 17:10:00':'2016-01-09 17:50:00','Dir78mS'] = np.nan
+    data_test.loc['2016-01-09 17:10:00':'2016-01-09 17:50:00','Spd80mN'] = np.nan
+    data_test.loc['2016-01-09 17:50:00':'2016-01-10 19:10:00','Dir58mS'] = np.nan
+    data_test.loc['2016-01-09 17:50:00':'2016-01-10 19:10:00','Spd60mN'] = np.nan
     ss_cor = bw.Correl.SpeedSort(data_test['Spd80mN'], data_test['Dir78mS'], data_test['Spd60mN'], data_test['Dir58mS'],
                                  averaging_prd='10min')
     ss_cor.run()
@@ -586,3 +586,43 @@ def test_speed_sort():
             assert round(ss_cor.params[key]['offset'], 0) == round(result[key]['offset'], 0)  # comes out different
             assert round(ss_cor.params[key]['slope'], 1) == round(result[key]['slope'], 1)  # comes out different
             assert round(ss_cor.params[key]['target_speed_cutoff'], 0) == round(result[key]['target_speed_cutoff'], 0)
+
+def test_mlp():
+    #reference nodes
+    v_wdnode = 'WD50m_deg'
+    v_wsnode = 'WS50m_m/s'
+    v_tnode = 'T2M_degC'
+    v_pnode = 'PS_hPa'
+
+    #onsite nodes
+    o_wsnode = 'Spd80mN'
+    o_wdnode = 'Dir78mS'
+    
+    mlp = bw.Correl.MultiLayerPerceptron(MERRA2_NE[[v_wsnode,v_wdnode, v_tnode, v_pnode]].dropna(), 
+                                     DATA_CLND[[o_wsnode, o_wdnode]].dropna(),
+                                     alpha=1,
+                                     ref_spd_col=v_wsnode,
+                                     tar_spd_col=o_wsnode,
+                                     ref_dir_col=v_wdnode,
+                                     tar_dir_col=o_wdnode,
+                                     averaging_prd='1H',
+                                     random_state=1 #we fix the randomisation for testing purposes
+                                     )
+    mlp.run()
+    synth = mlp.synthesize(ext_input=mlp.ref_spd[mlp._ref_spd_fit_col_names])
+
+    result_synth_mlp = {'Spd80mN_Synthesized': {'2000-01-01 00:00:00': 5.896543,
+                                          '2000-01-01 01:00:00': 5.330373,
+                                          '2000-01-01 02:00:00': 6.047403,
+                                          '2000-01-01 03:00:00': 7.350323,
+                                          '2000-01-01 04:00:00': 7.931148},												 
+                    'Dir78mS_Synthesized': {'2000-01-01 00:00:00': 273.912748,
+                                            '2000-01-01 01:00:00': 263.949254,
+                                            '2000-01-01 02:00:00': 254.722937,
+                                            '2000-01-01 03:00:00': 245.759566,
+                                            '2000-01-01 04:00:00': 237.516963},}
+    result = {'score': 0.8862840280503164}
+    assert round(mlp.score,4) == round(result['score'],4)
+    for idx, row in pd.DataFrame(result_synth_mlp).iterrows():
+        # Comparing the first 5 digits to avoid issuing with floating point precision
+        assert str(row.iloc[0])[0:5] == str(synth.loc[idx].iloc[0])[0:5]

--- a/tutorial/becoming_a_correlation_wizard.ipynb
+++ b/tutorial/becoming_a_correlation_wizard.ipynb
@@ -1,0 +1,827 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<center>\n",
+    "# How to become a correlation wizard with the brightwind library!\n",
+    "</center>\n",
+    "***"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import datetime\n",
+    "print('Last updated: {}'.format(datetime.date.today().strftime('%d %B, %Y')))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "***"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div style='margin-top: 3em; margin-bottom: 3em;'>\n",
+    "</div>\n",
+    "\n",
+    "## Outline:\n",
+    "\n",
+    "This guide will demonstrate various techniques to correlate a sample site dataset to 4 separate reference datasets using the following steps:\n",
+    "\n",
+    "- Import the brightwind library, load some sample raw data and clean it\n",
+    "- Import 4 sample reference datasets to use in the correlation\n",
+    "- Perform a ordinary least squares correlation for 1 dataset and time period\n",
+    "- Apply a long term adjustment to the measured wind speed time series based on the correlation results\n",
+    "- Perform a ordinary least squares correlation for multiple datasets and time periods\n",
+    "\n",
+    "***"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div style='margin-top: 3em; margin-bottom: 3em;'>\n",
+    "</div>\n",
+    "\n",
+    "### Import brightwind and data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# import the brightwind library\n",
+    "import brightwind as bw\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "***"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div style='margin-top: 3em; margin-bottom: 3em;'>\n",
+    "</div>\n",
+    "\n",
+    "### Import reference datasets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For this example, we will import 4 MERRA-2 reanalysis datasets. These can be found as sample datasets within the brightwind library. We use the `load_csv()` function to load in each dataset from a csv file."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "***"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div style='margin-top: 3em; margin-bottom: 3em;'>\n",
+    "</div>\n",
+    "\n",
+    "### Correlate to 1 dataset and using 1 averaging period"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next we'll perform a basic linear regression correlation using the Ordinary Least Squares method between the 80m north orientated site anemometer and the MERRA-2 dataset located to the North East. We use the 'averaging_prd' argument to set the averaging period for which the correlation should be carried out. This can be set to 10-min or multiples of ten minutes (10T, 30T) (depending on the interval of both datasets), hourly or multiples of 1 hour (1H, 2H, 3H, etc), daily or multiples of 1 day (1D, 2D, 3D, 15D, etc), monthly (1M) or yearly (1AS). Here we apply a monthly correlation. Finally we set the 'coverage_threshold', this is the minimum coverage of data within each averaging period from both the reference and site dataset that will be passed to the correlation. In this case we use a coverage threshold of 90%."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = bw.load_csv(bw.demo_datasets.demo_data)\n",
+    "m2_ne = bw.load_csv(bw.demo_datasets.demo_merra2_NE)\n",
+    "m2_se = bw.load_csv(bw.demo_datasets.demo_merra2_SE)\n",
+    "m2_nw = bw.load_csv(bw.demo_datasets.demo_merra2_NW)\n",
+    "m2_sw = bw.load_csv(bw.demo_datasets.demo_merra2_SW)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# set up ord lst correlation\n",
+    "ord_lst_sq = bw.Correl.OrdinaryLeastSquares(m2_ne['WS50m_m/s'], data['Spd80mN'], \n",
+    "                                            averaging_prd='1H', coverage_threshold=0.90)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div style='margin-top: 3em; margin-bottom: 3em;'>\n",
+    "</div>\n",
+    "\n",
+    "The correlation function returns a python object. This has to be subsequently run and plotted using the commands `run()` and `plot()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "# run correlation\n",
+    "ord_lst_sq.run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div style='margin-top: 3em; margin-bottom: 3em;'>\n",
+    "</div>\n",
+    "\n",
+    "The correlation has now run and the main results are returned. The slope and offset of the linear regression line are displayed along with the $R^2$  value. These results can be returned at any time using the `.show_params()` command."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#show parameters\n",
+    "ord_lst_sq.show_params()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div style='margin-top: 3em; margin-bottom: 3em;'>\n",
+    "</div>\n",
+    "\n",
+    "To show the correlation plot along with the linear regression line we simply input:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# show plot\n",
+    "ord_lst_sq.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div style='margin-top: 3em; margin-bottom: 3em;'>\n",
+    "</div>\n",
+    "\n",
+    "Now that we have a correlation we will want to adjust our data accordingly. We can synthesize monthly Spd80mN mean wind speeds from the Merra2_NE data using the `synthesize()` method. This will synthesize monthly means for months that Spd80mN doesn't cover and splices it with months Spd80mN does cover."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "# synthesize monthly means over the long term record\n",
+    "LT_monthly_means = ord_lst_sq.synthesize()\n",
+    "# Show the first 5 values\n",
+    "LT_monthly_means.head(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "***"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we use a more complex correlation, a multi layer perceptron combined with empirical quantile mapping. But the logic is similar to the previous regression, one difference being that the mlp here is multi variable, so several columns can be passed as inputs and outputs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#reference nodes\n",
+    "v_wdnode = 'WD50m_deg'\n",
+    "v_wsnode = 'WS50m_m/s'\n",
+    "v_tnode = 'T2M_degC'\n",
+    "v_pnode = 'PS_hPa'\n",
+    "\n",
+    "#onsite nodes\n",
+    "o_wsnode = 'Spd80mN'\n",
+    "o_wdnode = 'Dir78mS'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# set up correlation\n",
+    "mlp = bw.Correl.MultiLayerPerceptron(m2_ne[[v_wsnode,v_wdnode, v_tnode, v_pnode]].dropna(), \n",
+    "                                     data[[o_wsnode, o_wdnode]].dropna(),\n",
+    "                                     alpha=1,\n",
+    "                                     ref_spd_col=v_wsnode,\n",
+    "                                     tar_spd_col=o_wsnode,\n",
+    "                                     ref_dir_col=v_wdnode,\n",
+    "                                     tar_dir_col=o_wdnode,\n",
+    "                                     averaging_prd='1H'\n",
+    "                                     )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mlp.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mlp.synthesize(ext_input=mlp.ref_spd[mlp._ref_spd_fit_col_names])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mlp.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "However it's a good idea with this sort of machine learning to divide the measurements into a training and testing dataset. sklearn as very power tools to do that (using Cross Validation), but below we'll show just a simple way to do this."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#we define the dates of the training and testing periods\n",
+    "start_training = '2016-01-01'\n",
+    "end_training = '2016-12-31'\n",
+    "start_testing = '2017-01-01'\n",
+    "end_testing = '2017-12-31'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# set up correlation\n",
+    "mlp = bw.Correl.MultiLayerPerceptron(m2_ne[[v_wsnode,v_wdnode, v_tnode, v_pnode]].dropna(), \n",
+    "                                     data.loc[start_training:end_training,[o_wsnode, o_wdnode]].dropna(),\n",
+    "                                     alpha=1,\n",
+    "                                     ref_spd_col=v_wsnode,\n",
+    "                                     tar_spd_col=o_wsnode,\n",
+    "                                     ref_dir_col=v_wdnode,\n",
+    "                                     tar_dir_col=o_wdnode,\n",
+    "                                     averaging_prd='1H'\n",
+    "                                     )\n",
+    "mlp.run()\n",
+    "mlp_predicted = mlp.synthesize(ext_input=mlp.ref_spd[mlp._ref_spd_fit_col_names])\n",
+    "mlp.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mlp_predicted_training = mlp_predicted.loc[start_training:end_training, mlp._tar_spd_col_name+'_Synthesized']\n",
+    "mlp_predicted_training_merged = mlp.data[[mlp._tar_spd_col_name]].merge(mlp_predicted_training, left_index=True, right_index=True)\n",
+    "mlp_predicted_testing = mlp_predicted.loc[start_testing:end_testing, mlp._tar_spd_col_name+'_Synthesized']\n",
+    "mlp_predicted_testing_merged = data.loc[start_testing:end_testing,[o_wsnode]].merge(mlp_predicted_testing, left_index=True, right_index=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import scipy\n",
+    "fig, axes = plt.subplots(1, 2)\n",
+    "x1=mlp_predicted_training_merged.iloc[:,0]\n",
+    "y1=mlp_predicted_training_merged.iloc[:,1]\n",
+    "x2=mlp_predicted_testing_merged.iloc[:,0]\n",
+    "y2=mlp_predicted_testing_merged.iloc[:,1]\n",
+    "\n",
+    "slope1, intercept1, r_value1, p_value1, std_err1 = scipy.stats.linregress(x1, y1)\n",
+    "r2_1 = r_value1**2\n",
+    "\n",
+    "bw.plot_scatter(x1,\n",
+    "                y1,\n",
+    "                slope1*x1 + intercept1,\n",
+    "                x_label='Measured wind speed (training)', y_label='Predicted wind speed (training)',\n",
+    "                line_of_slope_1=False, trendline_name= 'Linear trendline (linear R²={})'.format(round(r2_1,2)),ax=axes[0])\n",
+    "\n",
+    "slope2, intercept2, r_value2, p_value2, std_err2 = scipy.stats.linregress(x2, y2)\n",
+    "r2_2 = r_value2**2\n",
+    "\n",
+    "bw.plot_scatter(x2,\n",
+    "                y2,\n",
+    "                slope1*x2 + intercept2,\n",
+    "                x_label='Measured wind speed (testing)', y_label='Predicted wind speed (testing)',\n",
+    "                line_of_slope_1=False, trendline_name= 'Linear trendline (linear R²={})'.format(round(r2_2,2)),ax=axes[1])\n",
+    "\n",
+    "#ideally the R² between the training and predicted periods should be balanced. If not it is recommended to change the alpha parameter of the mlp correlation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div style='margin-top: 3em; margin-bottom: 3em;'>\n",
+    "</div>\n",
+    "\n",
+    "### Apply a long term adjustment to the measured wind speed time series based on the correlation results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can use the results of the above correlation to rescale the Spd80mN wind speed time series and put it into a long term context. First we'll use the `momm()` (mean of monthly means) function to derive the long term mean of the dataset we synthesized above. This represents our target long term mean speed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# derive long term target mean speed \n",
+    "LT_target_speed = bw.momm(LT_monthly_means)\n",
+    "# show the value\n",
+    "LT_target_speed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div style='margin-top: 3em; margin-bottom: 3em;'>\n",
+    "</div>\n",
+    "\n",
+    "Next, we'll derive a scale factor we can apply to the measurements to achieve this long term mean."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# derive scale factor as ratio of means\n",
+    "LT_scale_factor = LT_target_speed/data.Spd80mN.mean()\n",
+    "# show the value\n",
+    "LT_scale_factor"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div style='margin-top: 2em; margin-bottom: 2em;'>\n",
+    "</div>\n",
+    "\n",
+    "Then, we can use the `scale_wind_speed()` function to rescale the measurements based on the above factor, placing them in a long term context. We'll also allocate this a new variable within the existing dataframe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# scale wind speed\n",
+    "data['Spd80mN_LT'] = bw.scale_wind_speed(data.Spd80mN, LT_scale_factor)\n",
+    "# show first 5 timestamps. The new variable can be seen in the last column of the dataframe.\n",
+    "data.head(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div style='margin-top: 2em; margin-bottom: 2em;'>\n",
+    "</div>\n",
+    "\n",
+    "Now, let's confirm that the mean of our new variable is equal to our long term mean speed target."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# show ratio of mean values\n",
+    "data.Spd80mN_LT.mean()/LT_target_speed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div style='margin-top: 2em; margin-bottom: 2em;'>\n",
+    "</div>\n",
+    "\n",
+    "The resulting variable can then be used along with concurrent wind direction data (such as 'data.Dir78mS') to generate a tab file for wind flow modelling as shown in the tutorial for [exporting a tab file](exporting_a_tab_file_and_saving_your_data.html). "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "***"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div style='margin-top: 3em; margin-bottom: 3em;'>\n",
+    "</div>\n",
+    "\n",
+    "### Correlation for multiple datasets and time periods\n",
+    "\n",
+    "<div style='margin-top: 2em; margin-bottom: 2em;'>\n",
+    "</div>\n",
+    "\n",
+    "> **Note**: in a future release we plan to create a more user-friendly wrapper to perform multiple correlations at once.\n",
+    "\n",
+    "<div style='margin-top: 2em; margin-bottom: 2em;'>\n",
+    "</div>\n",
+    "\n",
+    "As well as performing one correlation with specific parameters, the brightwind library can be used to correlate to multiple reference datasets using multiple averaging periods in one cell. The code below performs two 'for' loops to iterate through each of the MERRA-2 datasets and a number of averaging periods, and returns the results in a dataframe. In order to allocate the results as a dataframe, we need to first import the pandas library.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div style='margin-top: 2em; margin-bottom: 2em;'>\n",
+    "</div>\n",
+    "\n",
+    "We then assign each of the datasets to a python dictionary, so we can easily loop through them later."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "merra2_nodes = {\n",
+    "    'M2_NE': Merra2_NE,\n",
+    "    'M2_NW': Merra2_NW,\n",
+    "    'M2_SE': Merra2_SE,\n",
+    "    'M2_SW': Merra2_SW\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div style='margin-top: 2em; margin-bottom: 2em;'>\n",
+    "</div>\n",
+    "\n",
+    "The following code can then be used to run each for loop and add results to the new dataframe. Specific steps are explained in the comments throughout."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# set the target and reference column names\n",
+    "target_column = 'Spd80mN'\n",
+    "ref_column = 'WS50m_m/s'\n",
+    "\n",
+    "# create a list to store all of the results\n",
+    "correl_results = []\n",
+    "\n",
+    "# set up first loop, which will step through the 4 reanalysis datasets\n",
+    "for node in merra2_nodes:\n",
+    "    # set up the second loop, nested within the first one. This one will step through a number of averaging periods.\n",
+    "    for avg_prd in ['1D','3D','7D','15D','1M']:\n",
+    "        \n",
+    "        # set up the correlation object, as done previously\n",
+    "        ord_lst_sq = bw.Correl.OrdinaryLeastSquares(merra2_nodes[node][ref_column], data[target_column],\n",
+    "                                                    averaging_prd=avg_prd, coverage_threshold=0.90)\n",
+    "        # run the correlation\n",
+    "        ord_lst_sq.run()\n",
+    "        \n",
+    "        # Append the results to the results list\n",
+    "        correl_results.append({\n",
+    "            '1, Reanalysis dataset': node,\n",
+    "            '2, Averaging Period': avg_prd,\n",
+    "            '3, Num data points': ord_lst_sq.params['Num data points'],\n",
+    "            '4, LT Reference MOMM': bw.momm(merra2_nodes[node][ref_column]),\n",
+    "            '5, R^2': ord_lst_sq.params['r2'],\n",
+    "            '6, Slope': ord_lst_sq.params['slope'],\n",
+    "            '7, Offset': ord_lst_sq.params['offset'],\n",
+    "            '8, LT Target wind speed': bw.momm(ord_lst_sq.synthesize()),\n",
+    "            '9, Adjustment of mean [%]': ((bw.momm(ord_lst_sq.synthesize()) / data[target_column].mean())-1)*100,\n",
+    "        })"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div style='margin-top: 2em; margin-bottom: 2em;'>\n",
+    "</div>\n",
+    "\n",
+    "Each set of print results above are the result of the `obj.run()` function. We have saved a summary of the results under 'correl_results', so lets take a look at that now."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# put the list into a DataFrame for ease of analysis.\n",
+    "correl_results_df = pd.DataFrame(correl_results)\n",
+    "correl_results_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div style='margin-top: 2em; margin-bottom: 2em;'>\n",
+    "</div>\n",
+    "\n",
+    "We can easily scan down through the results to see the different $R^2$ values for different averaging periods and reanalysis datasets, and see other key metrics such as the predicted long term wind speed and the percentage adjustment from the measured site wind speed to the long term wind speed. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now lets scale the wind speed once again, this time based on the correlation with the highest $R^2$ value in our table. First, let's show all the parameters of the correlation with the max $R^2$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# show correlation results when r2 is equal to the max r2\n",
+    "correl_results_df[correl_results_df['5, R^2'] == max(correl_results_df['5, R^2'])]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div style='margin-top: 2em; margin-bottom: 2em;'>\n",
+    "</div>\n",
+    "\n",
+    "We can pull out the index of this correlation from our table by adding on `.index[0]` on the end amd assigning it to a variable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get row with the best correlation\n",
+    "row = correl_results_df[correl_results_df['5, R^2'] == max(correl_results_df['5, R^2'])].index[0]\n",
+    "# show index\n",
+    "row"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div style='margin-top: 2em; margin-bottom: 2em;'>\n",
+    "</div>\n",
+    "\n",
+    "Then we can refer to the long term target speed from this correlation as follows."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "correl_results_df['8, LT Target wind speed'][row]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div style='margin-top: 2em; margin-bottom: 2em;'>\n",
+    "</div>\n",
+    "\n",
+    "This can be used to derive a scale factor in the same way we did before."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# derive scale factor as ratio of means\n",
+    "LT_scale_factor = correl_results_df['8, LT Target wind speed'][row] / data[target_column].mean()\n",
+    "# show the value\n",
+    "LT_scale_factor"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div style='margin-top: 2em; margin-bottom: 2em;'>\n",
+    "</div>\n",
+    "\n",
+    "Finally, we can create a second LT adjusted time series using the same commands as before, once again add this to our existing DataFrame alongside the previous long term variable. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# scale wind speed\n",
+    "data['Spd80mN_LT_2'] = bw.scale_wind_speed(data[target_column], LT_scale_factor)\n",
+    "# show first 5 timestamps. The new variable can be seen to the right of the dataframe.\n",
+    "data.head(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div style='margin-top: 2em; margin-bottom: 2em;'>\n",
+    "</div>\n",
+    "\n",
+    "Of course, $R^2$ is not the only parameter than matters when deciding on a robust correlation method, so the analyst still has an important role! Nonetheless, this shows how easy the library makes it to compare large numbers of reference datasets and get back useful results fast. Upcoming updates to the library will aim to reduce the code required to perform the looping procedure, so watch this space!\n",
+    "\n",
+    "***"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div style='margin-top: 2em; margin-bottom: 2em;'>\n",
+    "</div>\n",
+    "\n",
+    "### Other correlation methods\n",
+    "\n",
+    "The library also includes a host of other correlation functions such as:\n",
+    "\n",
+    "- `SimpleSpeedRatio()`\n",
+    "- `OrthogonalLeastSquares()`\n",
+    "- `MultipleLinearRegression()`\n",
+    "- `Speedsort()`\n",
+    "- `SVR()`\n",
+    "\n",
+    "The `SimpleSpeedRatio()` is simply a ratio of the overlapping target and reference wind speed time series.\n",
+    "\n",
+    "The `OrthogonalLeastSquares()` function carries out a orthogonal least squares regression correlation. \n",
+    "\n",
+    "The `MultipleLinearRegression()` function allows linear regression to be carried out between multiple reference datasets and the site data.\n",
+    "\n",
+    "The `Speedsort()` function is a directional correlation method developed by Brian Hurley and Ciaran King as outlined in the paper \"The Speedsort, DynaSort and Scatter wind correlation methods\", Wind Engineering Volume 29, No.3, pp 217-241.\n",
+    "\n",
+    "The `SVR()` function is a support vector machine correlation method which is a type of Machine Learning alogorithim.\n",
+    "\n",
+    "These functions will be the subject of future tutorials relating to correlation methods."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "***"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div style='margin-top: 2em; margin-bottom: 2em;'>\n",
+    "</div>\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "brightwind",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Closes #524 

This is a proposal of a new correlation method, based on Multi Layer Perceptron using [sklearn ](https://scikit-learn.org/stable/modules/generated/sklearn.neural_network.MLPRegressor.html) along with [python-cmethods](https://github.com/btschwertfeger/python-cmethods) for Empirical Quantile Mapping from @btschwertfeger (Benjamin T. Schwertfeger. (2025). btschwertfeger/python-cmethods: v2.3.1 (v2.3.1). Zenodo. https://doi.org/10.5281/zenodo.15128642).

The MLP + EQM process is inspired by Vortex [Remodelling method](https://vortexfdc.com/resources/vortex-times-remodeling-methodology-validation/) from @gcavero98.

Thanks to @phil-brad for his introduction to sklearn ML regressions.


Note that this code is just a proof-of-concept for the time being and was tested on 1 site only. 

Formal validation MUST be done before using it for annual energy estimate.

