### PR TITLE
Iss602 update contributing docs for test envs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,3 @@ brightwind.egg-info/
 .venv/
 venv/
 env/
-brightwind_dev/

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,9 @@ tests/temp/*
 temp/*
 brightwind.egg-info/
 **/.ipynb_checkpoints
+
+### Virtual Environments ###
+.venv/
+venv/
+env/
+brightwind_dev/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ Additional labels for pre-release and build metadata are available as extensions
 XX-Xxx-2026
 
 ### New Features and Enhancements
-1. 
+1. Rewrote `README.md` and `contributing.md` to align with the [docs site](https://brightwind-dev.github.io/brightwind-docs/), with clearer install options (venv / conda), a quick-start example, and an expanded contributing guide covering the fork workflow, editable dev install and running the test suite. ([#602](https://github.com/brightwind-dev/brightwind/issues/602))
+2. `test_load_brighthub` is now skipped automatically when `BRIGHTHUB_CLIENT_ID` and `BRIGHTHUB_CLIENT_SECRET` environment variables are not set, so the test suite runs cleanly without BrightHub credentials. ([#602](https://github.com/brightwind-dev/brightwind/issues/602))
 
 ### Bug Fixes
 1. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ XX-Xxx-2026
 
 ### New Features and Enhancements
 1. Rewrote `README.md` and `contributing.md` to align with the [docs site](https://brightwind-dev.github.io/brightwind-docs/), with clearer install options (venv / conda), a quick-start example, and an expanded contributing guide covering the fork workflow, editable dev install and running the test suite. ([#602](https://github.com/brightwind-dev/brightwind/issues/602))
-2. `test_load_brighthub` is now skipped automatically when `BRIGHTHUB_CLIENT_ID` and `BRIGHTHUB_CLIENT_SECRET` environment variables are not set, so the test suite runs cleanly without BrightHub credentials. ([#602](https://github.com/brightwind-dev/brightwind/issues/602))
+2. `test_load_brighthub` is now skipped automatically when no BrightHub credentials are available — either `BRIGHTHUB_CLIENT_ID` and `BRIGHTHUB_CLIENT_SECRET`, or the deprecated `BRIGHTHUB_EMAIL` and `BRIGHTHUB_PASSWORD` — so the test suite runs cleanly without BrightHub credentials. ([#602](https://github.com/brightwind-dev/brightwind/issues/602))
 
 ### Bug Fixes
 1. 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ For full examples — loading, plotting, shear, correlations, exporting — see 
 ---
 ### Why open-source?
 
-Brightwind makes every step of an assessment transparent, auditable and reproducible. The full record of
+The brightwind library is open-source, making every step of an assessment transparent, auditable and reproducible. The full record of
 adjustments to a dataset lives in a single file that internal reviewers, third parties and banks can inspect
 directly — sharpening due diligence and removing the "black box" problem of proprietary tools.
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,21 @@ consultancy reinventing the same calculations behind closed doors.
 <br>
 
 ---
+### Test datasets
+
+Demo datasets are bundled with the library to demonstrate functions and exercise the test suite:
+
+| Dataset | Source | Notes |
+|:--- |:--- |:--- |
+| `demo_data.csv` | BrightWind | A modified 2-year met mast dataset in CSV and Campbell Scientific format. |
+| `MERRA-2_XX_2000-01-01_2017-06-30.csv` | NASA [GES DISC](https://disc.gsfc.nasa.gov/) | 4 × MERRA-2 18-year datasets to complement the demo data for long-term analyses. |
+| `demo_cleaning_file.csv` | BrightWind | Periods to clean out from the demo data. |
+| `windographer_flagging_log.txt` | BrightWind | Same cleaning info as `demo_cleaning_file.csv` formatted as a Windographer flagging file. |
+| `demo_data_iea43_wra_data_model.json` | BrightWind | A JSON file formatted to the IEA Wind Task 43 [WRA Data Model](https://github.com/IEA-Task-43/digital_wra_data_standard) standard, describing the mast configuration for the demo data. |
+
+<br>
+
+---
 ### Contributing
 
 Brightwind welcomes contributions from across the wind and solar industry — analysts, engineers, researchers and

--- a/README.md
+++ b/README.md
@@ -26,7 +26,18 @@ results to formats used by wind analysis software such as WAsP.
 
 Install brightwind into its own environment to avoid dependency clashes. Pick whichever option suits you.
 
-#### Option 1 — venv
+#### Option 1 — venv (quick way to try brightwind out)
+
+Check Python is installed (3.9+ recommended):
+
+```bash
+python --version
+```
+
+If not, install it from [python.org/downloads](https://www.python.org/downloads/) — on Windows, tick **"Add
+Python to PATH"** in the installer.
+
+Then create an environment and install brightwind:
 
 ```bash
 python -m venv brightwind_env
@@ -40,8 +51,9 @@ pip install brightwind
 
 #### Option 2 — conda
 
-New to Python? We recommend [Anaconda](https://www.datacamp.com/tutorial/installing-anaconda-windows), which
-bundles Python, pip and Jupyter. Then from the **Anaconda Prompt**:
+Common if you already use Anaconda or work primarily in Jupyter.
+[Anaconda](https://www.datacamp.com/tutorial/installing-anaconda-windows) bundles Python, pip and Jupyter in one
+installer. From the **Anaconda Prompt**:
 
 ```bash
 conda create --name brightwind_env python=3.11
@@ -81,6 +93,18 @@ For full examples — loading, plotting, shear, correlations, exporting — see 
 ![demo_image_1](read_me_1.png)
 ![demo_image_2](read_me_2.png)
 </p>
+
+<br>
+
+---
+### Why open-source?
+
+Brightwind makes every step of an assessment transparent, auditable and reproducible. The full record of
+adjustments to a dataset lives in a single file that internal reviewers, third parties and banks can inspect
+directly — sharpening due diligence and removing the "black box" problem of proprietary tools.
+
+The intent is a shared, validated toolkit that the wind and solar industry builds on together, rather than each
+consultancy reinventing the same calculations behind closed doors.
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -13,46 +13,67 @@
 
 <br>
 
-Brightwind is a Python library specifically built for wind analysis. It can load in wind speed, wind direction and 
-other metrological timeseries data. There are various plots you can use to understand this data and to find any 
-potential issues. You can perform many common functions to the data such as shear and long-term adjustments. The 
-resulting adjusted data is then outputted as a frequency distribution tab file which can be used in wind analysis 
-software such as WAsP.
+Brightwind is an open-source Python library for wind (and solar) resource analysis. It loads meteorological
+timeseries data, runs common analyses — shear, long-term adjustments, correlations, distributions — and exports
+results to formats used by wind analysis software such as WAsP.
 
-This library can also be used for solar resource analysis.
+📚 **Full documentation, tutorials and API reference:** https://brightwind-dev.github.io/brightwind-docs/
 
 <br>
 
 ---
 ### Installation
 
-You can use pip from the command line to install the library.
+Install brightwind into its own environment to avoid dependency clashes. Pick whichever option suits you.
 
+#### Option 1 — venv
+
+```bash
+python -m venv brightwind_env
+# Windows
+brightwind_env\Scripts\activate
+# macOS / Linux
+source brightwind_env/bin/activate
+
+pip install brightwind
 ```
-C:\Users\Stephen> pip install brightwind
+
+#### Option 2 — conda
+
+New to Python? We recommend [Anaconda](https://www.datacamp.com/tutorial/installing-anaconda-windows), which
+bundles Python, pip and Jupyter. Then from the **Anaconda Prompt**:
+
+```bash
+conda create --name brightwind_env python=3.11
+conda activate brightwind_env
+pip install brightwind
 ```
-It is advisable to use a separate environment to avoid any dependency clashes with other libraries such as Pandas, Numpy 
-or Matplotlib you may already have installed.
+
+A step-by-step Windows install walkthrough is also available in the
+[tutorials](https://brightwind-dev.github.io/brightwind-docs/).
 
 <br>
-
-For those that do not have Python installed and are just getting started, we recommend installing Anaconda. Anaconda is 
-a Python distribution for scientific computing and so provides everything you need, Python, pip and Jupyter Notebook 
-along with libraries such as Pandas, Numpy and Matplotlib. Datacamp provide a good tutorial for [installing 
-Anaconda on Windows](https://www.datacamp.com/tutorial/installing-anaconda-windows) to get started.
-
-Once Anaconda is installed, you can use the **Anaconda Prompt** to run the above command line `pip install brightwind`. 
-Or first use **Anaconda Navigator** to create an environment.
 
 ---
-### Documentation
+### Quick start
 
-Documentation on how to get setup and use the library can be found at https://brightwind-dev.github.io/brightwind-docs/
+Most analysts use brightwind from a Jupyter Notebook:
 
-<br>
+```bash
+pip install jupyter
+jupyter notebook
+```
 
-Example usage of the brightwind library is shown below using Jupyter Notebook. Jupyter Notebook is a powerful way to 
-immediately see the results of code you have written.
+```python
+import brightwind as bw
+
+data = bw.load_csv(bw.demo_datasets.demo_data)
+bw.basic_stats(data)
+```
+
+For full examples — loading, plotting, shear, correlations, exporting — see the
+[tutorials and API reference](https://brightwind-dev.github.io/brightwind-docs/).
+
 <br>
 
 <p>
@@ -61,58 +82,21 @@ immediately see the results of code you have written.
 ![demo_image_2](read_me_2.png)
 </p>
 
-
-
-
-<br>
-
-##### Features
-The library provides wind analysts with easy to use tools for working with
-meteorological data. It supports loading of meteorological data, averaging,
-filtering, plotting, correlations, shear analysis, long term adjustments, etc.
-The library can then export a resulting long term adjusted tab file to be used in
-other wind analysis software.
-
-<br>
-
-##### Benefits
-The key benefits to an open-source library is that it provides complete transparency
-and traceability. Anyone in the industry can review any part of the code and suggest changes,
-thus creating a standardised, validated toolkit for the industry.
-
-By default, during an assessment every manipulation or adjustment made to the wind data is
-contained in a single file. This can easily be reviewed and checked by internal reviewers or,
-as the underlying code is open-sourced, there is no reason why this file cannot be sent to
-3rd parties for review thus increasing the effectiveness of a banks due diligence.
-
-<br>
-
-##### License
-The library is licensed under the MIT license.
-
-<br>
-
----
-### Test datasets
-A test dataset is included in this repository and is used to demonstrate function and test functions in the code. 
-Other files and datasets are also included to complement this demo dataset. These are outlined below:
-
-<br>
-
-| Dataset               | Source           | Notes  |
-|:--------------------- |:-------------|:-----|
-| demo_data.csv         | BrightWind | A modified 2 year met mast dataset in csv and Campbell Scientific format. |
-| MERRA-2_XX_2000-01-01_2017-06-30.csv | NASA [GES DISC](https://disc.gsfc.nasa.gov/) | 4 x MERRA-2 18-yr datasets to complement the demo data for long term analyses. |
-| demo_cleaning_file.csv | BrightWind | A file containing information on what periods to clean out from the demo data. |
-| windographer_flagging_log.txt | BrightWind | The same cleaning info as found in 'demo_cleaning_file.csv' formatted as a Windographer flagging file. |
-| demo_data_iea43_wra_data_model.json | BrightWind | A JSON file formatted according to the IEA Wind Task 43 [WRA Data Model](https://github.com/IEA-Task-43/digital_wra_data_standard) standard which describes the mast configuration for the demo data. |
-
 <br>
 
 ---
 ### Contributing
-If you wish to be involved or find out more please contact stephen@brightwindanalysis.com.
 
-More information can be found in the [contributing.md](https://github.com/brightwind-dev/brightwind/blob/master/contributing.md) section of the website.
+Brightwind welcomes contributions from across the wind and solar industry — analysts, engineers, researchers and
+developers.
+
+- **Issues, bugs and feature requests:** [GitHub issue tracker](https://github.com/brightwind-dev/brightwind/issues)
+- **Code contributions and development setup:** see [contributing.md](contributing.md)
+- **General enquiries:** stephen@brightwindanalysis.com
 
 <br>
+
+---
+### License
+
+MIT — see [LICENSE.txt](LICENSE.txt).

--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ pip install brightwind
 A step-by-step Windows install walkthrough is also available in the
 [tutorials](https://brightwind-dev.github.io/brightwind-docs/).
 
+**Optional — parquet support**
+
+Reading `.parquet` files from BrightHub needs a parquet engine. Install the default (pyarrow):
+
+```bash
+pip install brightwind[parquet]
+```
+
+Or use fastparquet instead: `pip install brightwind[parquet-fastparquet]`.
+
 <br>
 
 ---

--- a/contributing.md
+++ b/contributing.md
@@ -1,48 +1,144 @@
-Contributing
-============
+# Contributing
 
-## Issue Tracking
+Brightwind is an **open-source library** and contributions from the wind and solar industry are warmly welcomed —
+analysts, engineers, researchers and developers. Bug fixes, new features, docs improvements and feedback all help
+build a standardised, validated toolkit for the industry.
 
-New feature requests, changes, enhancements, non-methodology features, and bug reports can be filed as new issues in the
-[GitHub.com issue tracker](https://github.com/brightwind-dev/brightwind/issues) at any time. Please be sure to fully describe the
-issue.
+For library usage and tutorials, see the [documentation site](https://brightwind-dev.github.io/brightwind-docs/).
+This guide covers contributing to the **codebase itself**.
 
+---
 
-## Repository
+## Reporting issues
 
-The brightwind repository is hosted on GitHub, and located here: https://github.com/brightwind-dev/brightwind
+Search the [issue tracker](https://github.com/brightwind-dev/brightwind/issues) before opening a new issue. When
+reporting a bug or requesting a feature, please include:
 
-This repository is organized using a modified git-flow system. Branches are organized as follows:
+- A clear, descriptive title.
+- What you expected to happen, and what actually happened.
+- A minimal code example that reproduces the problem.
+- Your brightwind version, Python version and operating system.
 
-- master: Stable release version. Must have good test coverage and may not have all the newest features.
-- dev: Development branch which contains the newest features. Tests must pass, but code may be unstable.
-- feature/xxx: Branch from dev, should reference a GitHub issue number.
+---
 
-To work on a feature, first create an issue exaplaining the issue or idea and clone the repository locally when you are ready to get to work.
+## Development workflow
 
-Once you have successfully cloned, create a feature branch from the dev branch. Please name your branch with the issue number you are working from e.g. `iss255_fix_bug`. Work out of this feature branch and push changes to it before submitting a pull request.
+The repo follows a modified git-flow:
 
-Commit messages should contain the issue number, preceded with a #, so these commits can automatically show up in the issue conversation e.g. `git commit -m "iss #255 bug fixed"`.
+- **`master`** — stable release.
+- **`dev`** — newest features; tests must pass.
+- **`iss<number>_<short_description>`** — feature branches off `dev`, one per issue.
 
-Be sure to periodically synchronize the upstream dev branch into your feature branch to avoid conflicts in the pull request. You can continue to iterate on your feature branch until you are ready to submit your pull request.
+### Branching and committing
 
-When the feature branch is ready, make a pull request to the dev branch through the GitHub.com UI.
+1. Sync `dev`:
+   ```bash
+   git checkout dev
+   git pull
+   ```
 
-## Pull Request
+2. Create a feature branch named after the issue:
+   ```bash
+   git checkout -b iss123_short_description
+   ```
 
-Pull requests must be made for any changes to be merged into release branches.
-They must include updated documentation and pass all unit tests and integration tests.
-In addition, code coverage should not be negatively affected by the pull request.
+3. Keep changes small and focused. Verify before committing:
+   ```bash
+   git diff
+   git status
+   ```
 
-**Scope:**
-Encapsulate the changes of ideally one, or potentially a couple, issues.
-It is greatly preferable to submit three small pull requests than it is to submit one large pull request.
-Write a complete description of these changes in the pull request body.
+4. Commit with a message that **starts with the issue number** (the space between `iss` and `#` links the commit
+   to the issue on GitHub):
+   ```bash
+   git commit -m "iss #123 short description of the change"
+   ```
 
-**Tests:**
-The contributor should write a test to cover the new changes.
+5. Push:
+   ```bash
+   git push -u origin iss123_short_description
+   ```
 
-**Documentation:**
-Function docstrings should be fully updated to explain any behaviour changes to the user along with examples. For complicated logic some inline comments are encouraged.
+### Pull requests
 
-**Changelog:** For pull requests that encapsulate a user-facing feature, or is significant to other contributors for some other reason, please add a line to CHANGELOG.md in the [Unreleased] section.
+Open PRs against **`dev`**, not `master`.
+
+Before raising a PR:
+
+- All tests pass — see [Running tests](#running-tests).
+- Add a [CHANGELOG.md](CHANGELOG.md) entry under `[Unreleased]` for user-facing changes.
+- Update docstrings for new or changed behaviour.
+- Add a test for new functionality or bug fixes.
+
+In the PR, keep the scope focused (ideally one issue), reference the issue number in the title
+(e.g. `[iss123] Short description`), and clearly explain what changed and why.
+
+---
+
+## Development setup
+
+Install brightwind in **editable mode** in a dedicated environment.
+
+### Option 1 — venv
+
+```bash
+python -m venv brightwind_dev
+# Windows
+brightwind_dev\Scripts\activate
+# macOS / Linux
+source brightwind_dev/bin/activate
+```
+
+### Option 2 — conda
+
+```bash
+conda create --name brightwind_dev python=3.11
+conda activate brightwind_dev
+```
+
+### Editable install
+
+With the environment active:
+
+```bash
+git clone https://github.com/brightwind-dev/brightwind.git
+cd brightwind
+pip install -e .
+```
+
+The `-e` flag links the install to your local clone, so code changes are picked up without reinstalling.
+
+---
+
+## Running tests
+
+From the repo root:
+
+```bash
+pytest tests/
+```
+
+Single file or single test:
+
+```bash
+pytest tests/test_load.py
+pytest tests/test_load.py::test_load_brighthub -v
+```
+
+All tests must pass before raising a PR. New functionality should include tests covering normal behaviour and
+edge cases.
+
+---
+
+## Code standards
+
+- **UK English** in comments, docstrings and user-facing strings (e.g. "analyse", "colour", "metres").
+- **Docstrings** use reStructuredText style (`:param`, `:type`, `:return`, `:rtype`) — see existing functions
+  for examples.
+- **Follow existing patterns** in the codebase.
+- **Wind and solar industry terminology** used correctly and consistently.
+
+---
+
+The library is licensed under the MIT license. By contributing you agree that your contributions will be licensed
+under the same terms.

--- a/contributing.md
+++ b/contributing.md
@@ -148,7 +148,11 @@ edge cases.
 Some tests hit the live [BrightHub](https://brighthub.io) API and require API credentials. They are automatically
 **skipped** if the credentials are not set, so the rest of the suite runs cleanly without them.
 
-To run the BrightHub tests, set the following environment variables before running `pytest`:
+To run the BrightHub tests, set **either** an API key pair **or** an email/password pair as environment variables
+before running `pytest`.
+
+Using an API key (recommended — generate one from
+[brighthub.io/account-settings/settings](https://brighthub.io/account-settings/settings)):
 
 ```bash
 # Windows (PowerShell, current session)
@@ -160,7 +164,18 @@ export BRIGHTHUB_CLIENT_ID="your-client-id"
 export BRIGHTHUB_CLIENT_SECRET="your-client-secret"
 ```
 
-Generate an API key from [brighthub.io/account-settings/settings](https://brighthub.io/account-settings/settings).
+Using email and password (deprecated — will be removed in the next major release (v3.0); not available for
+Microsoft SSO users):
+
+```bash
+# Windows (PowerShell, current session)
+$env:BRIGHTHUB_EMAIL="your-email"
+$env:BRIGHTHUB_PASSWORD="your-password"
+
+# macOS / Linux
+export BRIGHTHUB_EMAIL="your-email"
+export BRIGHTHUB_PASSWORD="your-password"
+```
 
 ---
 

--- a/contributing.md
+++ b/contributing.md
@@ -123,6 +123,14 @@ pip install -e .
 
 The `-e` flag links the install to your local clone, so code changes are picked up without reinstalling.
 
+To work on or test parquet loading, include the optional engine (pyarrow by default):
+
+```bash
+pip install -e .[parquet]
+```
+
+Or use fastparquet instead: `pip install -e .[parquet-fastparquet]`.
+
 ---
 
 ## Running tests
@@ -147,6 +155,8 @@ edge cases.
 
 Some tests hit the live [BrightHub](https://brighthub.io) API and require API credentials. They are automatically
 **skipped** if the credentials are not set, so the rest of the suite runs cleanly without them.
+
+Tests covering `.parquet` downloads also require the `[parquet]` extra (see [Development setup](#development-setup)) — they are skipped otherwise.
 
 To run the BrightHub tests, set **either** an API key pair **or** an email/password pair as environment variables
 before running `pytest`.

--- a/contributing.md
+++ b/contributing.md
@@ -98,7 +98,7 @@ conda activate brightwind_dev
 
 ### Editable install
 
-With the environment active:
+With the environment active, clone the repo and install brightwind in editable mode:
 
 ```bash
 git clone https://github.com/brightwind-dev/brightwind.git

--- a/contributing.md
+++ b/contributing.md
@@ -29,39 +29,54 @@ The repo follows a modified git-flow:
 - **`dev`** — newest features; tests must pass.
 - **`iss<number>_<short_description>`** — feature branches off `dev`, one per issue.
 
-### Branching and committing
+### Fork, branch and commit
 
-1. Sync `dev`:
+Brightwind follows the standard open-source fork-based workflow.
+
+> **Internal BrightWind contributors** with push access to `brightwind-dev/brightwind` can skip step 1 and
+> clone the upstream repo directly.
+
+1. **Fork the repo** on GitHub — click the **Fork** button (top-right of the
+   [brightwind repo page](https://github.com/brightwind-dev/brightwind)).
+
+2. **Clone your fork** locally:
    ```bash
-   git checkout dev
-   git pull
+   git clone https://github.com/YOUR_USERNAME/brightwind.git
+   cd brightwind
    ```
 
-2. Create a feature branch named after the issue:
+3. **Add the upstream remote** so you can pull future changes from the main repo:
    ```bash
+   git remote add upstream https://github.com/brightwind-dev/brightwind.git
+   ```
+
+4. **Sync `dev`** and create a feature branch named after the issue:
+   ```bash
+   git checkout dev
+   git pull upstream dev
    git checkout -b iss123_short_description
    ```
 
-3. Keep changes small and focused. Verify before committing:
+5. Keep changes small and focused. Verify before committing:
    ```bash
    git diff
    git status
    ```
 
-4. Commit with a message that **starts with the issue number** (the space between `iss` and `#` links the commit
-   to the issue on GitHub):
+6. **Commit** with a message that **starts with the issue number** (the space between `iss` and `#` links the
+   commit to the issue on GitHub):
    ```bash
    git commit -m "iss #123 short description of the change"
    ```
 
-5. Push:
+7. **Push to your fork**:
    ```bash
    git push -u origin iss123_short_description
    ```
 
 ### Pull requests
 
-Open PRs against **`dev`**, not `master`.
+Open PRs from your fork's feature branch into **`brightwind-dev/brightwind:dev`** — not `master`.
 
 Before raising a PR:
 
@@ -127,6 +142,25 @@ pytest tests/test_load.py::test_load_brighthub -v
 
 All tests must pass before raising a PR. New functionality should include tests covering normal behaviour and
 edge cases.
+
+### Integration tests against BrightHub
+
+Some tests hit the live [BrightHub](https://brighthub.io) API and require API credentials. They are automatically
+**skipped** if the credentials are not set, so the rest of the suite runs cleanly without them.
+
+To run the BrightHub tests, set the following environment variables before running `pytest`:
+
+```bash
+# Windows (PowerShell, current session)
+$env:BRIGHTHUB_CLIENT_ID="your-client-id"
+$env:BRIGHTHUB_CLIENT_SECRET="your-client-secret"
+
+# macOS / Linux
+export BRIGHTHUB_CLIENT_ID="your-client-id"
+export BRIGHTHUB_CLIENT_SECRET="your-client-secret"
+```
+
+Generate an API key from [brighthub.io/account-settings/settings](https://brighthub.io/account-settings/settings).
 
 ---
 

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -271,7 +271,10 @@ def test_load_brighthub_get_data_csv_explicit_no_warning():
 
 
 def test_load_brighthub_get_data_parquet():
-    pytest.importorskip('pyarrow', reason="parquet engine required to round-trip parquet bytes")
+    try:
+        import pyarrow  # noqa: F401
+    except ImportError:
+        pytest.importorskip('fastparquet', reason="parquet engine (pyarrow or fastparquet) required to round-trip parquet bytes")
 
     index = pd.to_datetime(['2016-06-01 00:00:00', '2016-06-01 00:10:00'])
     index.name = 'Timestamp'

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -158,6 +158,11 @@ def test_load_campbell_scientific():
             data1['2016-01-09 15:30:00':'2016-01-10 23:50:00'].fillna(-999)).all().all()
 
 
+@pytest.mark.skipif(
+    not (os.environ.get('BRIGHTHUB_CLIENT_ID') and os.environ.get('BRIGHTHUB_CLIENT_SECRET')),
+    reason="BRIGHTHUB_CLIENT_ID and BRIGHTHUB_CLIENT_SECRET must be set to run this integration test "
+           "against the live BrightHub API."
+)
 def test_load_brighthub():
 
     plant_uuid = '7a58497e-bee1-42a2-8084-c47a5cf213b7'

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -159,9 +159,12 @@ def test_load_campbell_scientific():
 
 
 @pytest.mark.skipif(
-    not (os.environ.get('BRIGHTHUB_CLIENT_ID') and os.environ.get('BRIGHTHUB_CLIENT_SECRET')),
-    reason="BRIGHTHUB_CLIENT_ID and BRIGHTHUB_CLIENT_SECRET must be set to run this integration test "
-           "against the live BrightHub API."
+    not (
+        (os.environ.get('BRIGHTHUB_CLIENT_ID') and os.environ.get('BRIGHTHUB_CLIENT_SECRET'))
+        or (os.environ.get('BRIGHTHUB_EMAIL') and os.environ.get('BRIGHTHUB_PASSWORD'))
+    ),
+    reason="Either BRIGHTHUB_CLIENT_ID and BRIGHTHUB_CLIENT_SECRET, or BRIGHTHUB_EMAIL and BRIGHTHUB_PASSWORD "
+           "must be set to run this integration test against the live BrightHub API."
 )
 def test_load_brighthub():
 


### PR DESCRIPTION
## Summary

Aligns `README.md` and `contributing.md` with the [docs site](https://brightwind-dev.github.io/brightwind-docs/), and stops the live BrightHub integration test from failing on machines without API credentials.

## Changes

- **README.md** — split install into venv / conda options, added a quick-start example, new "Why open-source?" section, tidied test datasets table.
- **contributing.md** — documents the fork workflow, editable dev install (venv or conda), and running tests (including `BRIGHTHUB_CLIENT_ID` / `BRIGHTHUB_CLIENT_SECRET` env vars for the BrightHub integration test).
- **tests/test_load.py** — `test_load_brighthub` now skipped via `pytest.mark.skipif` when BrightHub credentials aren't set.
- **.gitignore** — adds `.venv/`, `venv/`, `env/`.
- **CHANGELOG.md** — entries under `[2.X.X]`.

## Issue

Closes #602

## Test plan

- [x] `pytest tests/` passes with no BrightHub credentials set (BrightHub test skipped).
- [x] `pytest tests/` passes with `BRIGHTHUB_CLIENT_ID` / `BRIGHTHUB_CLIENT_SECRET` set (BrightHub test runs).
- [x] README and `contributing.md` render correctly on GitHub.
- [x] Fresh `python -m venv` → `pip install -e .` works following the contributing.md steps.
