### PR TITLE
Iss601 read brighthub timeseries as parquet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,13 @@ Additional labels for pre-release and build metadata are available as extensions
 XX-Xxx-2026
 
 ### New Features and Enhancements
-1. 
+1. Added support for reading Parquet files from BrightHub in `LoadBrightHub.get_data()` via a new `file_extension` argument (one of `'.csv'` or `'.parquet'`). Default remains `'.csv'` for backwards compatibility; Parquet is expected to become the default in the next major release. Reading Parquet requires a parquet engine — install with `pip install brightwind[parquet]` (pyarrow) or `pip install brightwind[parquet-fastparquet]` (fastparquet). ([#601](https://github.com/brightwind-dev/brightwind/issues/601))
 
 ### Bug Fixes
 1. 
 
 ### Deprecated
-1. 
+1. The implicit default of `file_extension='.csv'` in `LoadBrightHub.get_data()` is deprecated and will change to `'.parquet'` in the next major release. Calls that do not pass `file_extension` explicitly will emit a `DeprecationWarning`. Pass `file_extension='.csv'` to keep the current behaviour, or `file_extension='.parquet'` to opt in early. ([#601](https://github.com/brightwind-dev/brightwind/issues/601))
 
 ---
 ## [2.6.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ Given a version number MAJOR.MINOR.PATCH, increment the:
 Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.
 
 ---
-## [2.X.X]
-XX-Xxx-2026
+## [2.7.0]
+XX-May-2026
 
 ### New Features and Enhancements
 1. Added support for reading Parquet files from BrightHub in `LoadBrightHub.get_data()` via a new `file_extension` argument (one of `'.csv'` or `'.parquet'`). Default remains `'.csv'` for backwards compatibility; Parquet is expected to become the default in the next major release. Reading Parquet requires a parquet engine — install with `pip install brightwind[parquet]` (pyarrow) or `pip install brightwind[parquet-fastparquet]` (fastparquet). ([#601](https://github.com/brightwind-dev/brightwind/issues/601))

--- a/brightwind/load/load.py
+++ b/brightwind/load/load.py
@@ -9,7 +9,7 @@ import errno
 import os
 import shutil
 import json
-from io import StringIO
+from io import StringIO, BytesIO
 import warnings
 from dateutil.parser import parse
 from brightwind.analyse import plot as bw_plt
@@ -30,6 +30,8 @@ __all__ = ['load_csv',
            'apply_cleaning',
            'apply_cleaning_rules',
            'apply_cleaning_windographer']
+
+_FILE_EXTENSION_NOT_SET = object()
 
 OPERATOR_DICT = {
     1: operator.lt,
@@ -1491,19 +1493,19 @@ class LoadBrightHub:
         return date_str
 
     @staticmethod
-    def __get_timeseries_data(measurement_station_uuid, date_from=None, date_to=None):
+    def __get_timeseries_data(measurement_station_uuid, date_from=None, date_to=None, file_extension='.csv'):
         """
         Sub function to return the Brighthub GET timeseries-data API response.
         """
         date_from = LoadBrightHub.__date_to_datetime_str(date_from)
         date_to = LoadBrightHub.__date_to_datetime_str(date_to)
-        
+
         return LoadBrightHub._brighthub_request(
             url_end=f"/measurement-locations/{measurement_station_uuid}/timeseries-data",
-            params={"date_from": date_from, "date_to": date_to})
+            params={"date_from": date_from, "date_to": date_to, "file_extension": file_extension})
 
     @staticmethod
-    def get_data(measurement_station_uuid, date_from=None, date_to=None):
+    def get_data(measurement_station_uuid, date_from=None, date_to=None, file_extension=_FILE_EXTENSION_NOT_SET):
         """
         Get the timeseries data from BrightHub for a particular measurement station.
 
@@ -1516,6 +1518,17 @@ class LoadBrightHub:
         :type date_from:                 str
         :param date_to:                  Optional filter to retrieve data up to this date.
         :type date_to:                   str
+        :param file_extension:           File format to request from BrightHub. One of '.csv' (current default) or
+                                         '.parquet'. Reading '.parquet' requires either ``pyarrow`` or ``fastparquet``
+                                         to be installed (``pip install brightwind[parquet]`` for ``pyarrow``, or
+                                         ``pip install brightwind[parquet-fastparquet]`` for ``fastparquet``).
+
+                                         .. deprecated::
+                                             The default of '.csv' is retained for backwards compatibility and will
+                                             change to '.parquet' in the next major release of brightwind. Pass
+                                             ``file_extension`` explicitly to silence the DeprecationWarning and lock
+                                             in the desired format.
+        :type file_extension:            str
         :return:                         The timeseries data.
         :rtype:                          pd.DataFrame
 
@@ -1544,8 +1557,31 @@ class LoadBrightHub:
             data = bw.LoadBrightHub.get_data(measurement_station_uuid='9344e576-6d5a-45f0-9750-2a7528ebfa14',
                                              date_to='2016-07-01')
 
+        To get data as a parquet file (faster downloads and preserves dtypes; requires a parquet engine to be
+        installed)
+        ::
+            data = bw.LoadBrightHub.get_data(measurement_station_uuid='9344e576-6d5a-45f0-9750-2a7528ebfa14',
+                                             file_extension='.parquet')
+
         """
-        response = LoadBrightHub.__get_timeseries_data(measurement_station_uuid, date_from, date_to)
+        if file_extension is _FILE_EXTENSION_NOT_SET:
+            warnings.warn(
+                "The default file_extension for LoadBrightHub.get_data will change from '.csv' to '.parquet' in the "
+                "next major release of brightwind. Pass file_extension='.csv' explicitly to keep the current "
+                "behaviour, or file_extension='.parquet' to opt in early. Reading parquet requires a parquet engine: "
+                "`pip install brightwind[parquet]` (pyarrow) or `pip install brightwind[parquet-fastparquet]` "
+                "(fastparquet).",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            file_extension = '.csv'
+
+        if file_extension not in ('.csv', '.parquet'):
+            raise ValueError(
+                f"Unsupported file_extension '{file_extension}'. Expected '.csv' or '.parquet'."
+            )
+
+        response = LoadBrightHub.__get_timeseries_data(measurement_station_uuid, date_from, date_to, file_extension)
         response_json = response.json()
 
         # Handle 503 Service Unavailable error response using Retry-After header.
@@ -1556,7 +1592,9 @@ class LoadBrightHub:
             retry_after = int(response.headers.get('Retry-After', 60))  # default retry after default 60 seconds
             for _ in range(4):  # attempt 4 more times
                 time.sleep(retry_after)  # wait before retrying
-                response = LoadBrightHub.__get_timeseries_data(measurement_station_uuid, date_from, date_to)
+                response = LoadBrightHub.__get_timeseries_data(
+                    measurement_station_uuid, date_from, date_to, file_extension
+                )
                 response_json = response.json()
                 if response.status_code == 503 and assembly_in_progress_err_msg in response_json.get('details'):
                     retry_after *= 2  # double the retry time for each attempt
@@ -1580,6 +1618,16 @@ class LoadBrightHub:
         except requests.exceptions.RequestException as e:
             # Handle all request-related errors
             raise RuntimeError(f"An error occurred while fetching the data: {e}")
+
+        if file_extension == '.parquet':
+            try:
+                return pd.read_parquet(BytesIO(timeseries_response.content), engine='auto')
+            except ImportError as e:
+                raise ImportError(
+                    "Reading parquet requires a parquet engine. Install one with "
+                    "`pip install brightwind[parquet]` (pyarrow) or "
+                    "`pip install brightwind[parquet-fastparquet]` (fastparquet)."
+                ) from e
 
         df = pd.read_csv(StringIO(timeseries_response.text))
         df['Timestamp'] = pd.to_datetime(df['Timestamp'])  # this throws error if return doesn't have 'Timestamp'

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,12 @@ setup(
         'jsonschema>=4.17.3',
         'jinja2>= 3.0.0'
     ],
+    extras_require={
+        # Optional parquet engines for LoadBrightHub.get_data(file_extension='.parquet').
+        # pandas picks the installed engine at read time (prefers pyarrow, falls back to fastparquet).
+        'parquet': ['pyarrow>=5.0.0'],
+        'parquet-fastparquet': ['fastparquet>=0.8.0'],
+    },
     classifiers=[
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,10 +1,12 @@
 import pytest
 import brightwind as bw
 import os
+import warnings
 import pandas as pd
 import numpy as np
 import json
-from unittest.mock import patch
+from io import BytesIO
+from unittest.mock import patch, MagicMock
 
 DEMO_DATA_FOLDER = os.path.join(os.path.dirname(__file__), '../brightwind/demo_datasets')
 
@@ -210,10 +212,17 @@ def test_load_brighthub():
                                                 ) == test_period_demo_data
 
     # To get data for a specific time period for a specific measurement station
-    data_columns = bw.LoadBrightHub.get_data(measurement_station_uuid=measurement_station_uuid, date_from='2016-12-01',
-                                             date_to='2017-01-01').columns
+    data_csv = bw.LoadBrightHub.get_data(measurement_station_uuid=measurement_station_uuid, date_from='2016-12-01',
+                                         date_to='2017-01-01', file_extension='.csv')
     for col in ['Spd80mN', 'Spd80mS', 'Dir78mS']:
-        assert col in data_columns
+        assert col in data_csv.columns
+
+    # Same window as parquet — confirms the API accepts file_extension='.parquet' and returns equivalent data.
+    data_parquet = bw.LoadBrightHub.get_data(measurement_station_uuid=measurement_station_uuid, date_from='2016-12-01',
+                                             date_to='2017-01-01', file_extension='.parquet')
+    assert list(data_parquet.columns) == list(data_csv.columns)
+    assert len(data_parquet) == len(data_csv)
+    assert data_parquet.index.name == 'Timestamp'
 
     # To get cleaning log
     cleaning_log_df = bw.LoadBrightHub.get_cleaning_log(measurement_station_uuid=measurement_station_uuid)
@@ -222,3 +231,79 @@ def test_load_brighthub():
     # To get cleaning rules
     cleaning_rules_json = bw.LoadBrightHub.get_cleaning_rules(measurement_station_uuid=measurement_station_uuid)
     assert cleaning_rules_json[0]['measurement_location_uuid'] == measurement_station_uuid
+
+
+def test_load_brighthub_get_data_default_emits_deprecation_warning():
+    api_response = MagicMock(status_code=200)
+    api_response.json.return_value = {'url': 'https://example.com/presigned'}
+    csv_response = MagicMock(text='Timestamp,Spd80mN\n2016-06-01 00:00:00,7.1\n')
+
+    with patch('brightwind.load.load.LoadBrightHub._brighthub_request', return_value=api_response) as mock_request, \
+            patch('brightwind.load.load.requests.get', return_value=csv_response):
+        with pytest.warns(DeprecationWarning, match="file_extension"):
+            df = bw.LoadBrightHub.get_data(measurement_station_uuid='uuid-1')
+
+    assert mock_request.call_args.kwargs['params']['file_extension'] == '.csv'
+    assert df.index.name == 'Timestamp'
+
+
+def test_load_brighthub_get_data_csv_explicit_no_warning():
+    api_response = MagicMock(status_code=200)
+    api_response.json.return_value = {'url': 'https://example.com/presigned'}
+    csv_response = MagicMock(text='Timestamp,Spd80mN\n2016-06-01 00:00:00,7.1\n')
+
+    with patch('brightwind.load.load.LoadBrightHub._brighthub_request', return_value=api_response) as mock_request, \
+            patch('brightwind.load.load.requests.get', return_value=csv_response):
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', DeprecationWarning)
+            df = bw.LoadBrightHub.get_data(measurement_station_uuid='uuid-1', file_extension='.csv')
+
+    assert mock_request.call_args.kwargs['params']['file_extension'] == '.csv'
+    assert isinstance(df.index, pd.DatetimeIndex)
+
+
+def test_load_brighthub_get_data_parquet():
+    pytest.importorskip('pyarrow', reason="parquet engine required to round-trip parquet bytes")
+
+    index = pd.to_datetime(['2016-06-01 00:00:00', '2016-06-01 00:10:00'])
+    index.name = 'Timestamp'
+    sample = pd.DataFrame({'Spd80mN': [7.1, 7.3]}, index=index)
+    buffer = BytesIO()
+    sample.to_parquet(buffer, compression='snappy')
+
+    api_response = MagicMock(status_code=200)
+    api_response.json.return_value = {'url': 'https://example.com/presigned'}
+    parquet_response = MagicMock(content=buffer.getvalue())
+
+    with patch('brightwind.load.load.LoadBrightHub._brighthub_request', return_value=api_response) as mock_request, \
+            patch('brightwind.load.load.requests.get', return_value=parquet_response):
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', DeprecationWarning)
+            df = bw.LoadBrightHub.get_data(measurement_station_uuid='uuid-1', file_extension='.parquet')
+
+    assert mock_request.call_args.kwargs['params']['file_extension'] == '.parquet'
+    assert df.index.name == 'Timestamp'
+    assert isinstance(df.index, pd.DatetimeIndex)
+    assert np.allclose(df['Spd80mN'].values, sample['Spd80mN'].values)
+
+
+def test_load_brighthub_get_data_invalid_extension():
+    with patch('brightwind.load.load.LoadBrightHub._brighthub_request') as mock_request, \
+            patch('brightwind.load.load.requests.get') as mock_get:
+        with pytest.raises(ValueError, match="Unsupported file_extension"):
+            bw.LoadBrightHub.get_data(measurement_station_uuid='uuid-1', file_extension='.xlsx')
+
+    mock_request.assert_not_called()
+    mock_get.assert_not_called()
+
+
+def test_load_brighthub_get_data_parquet_missing_engine_raises_importerror():
+    api_response = MagicMock(status_code=200)
+    api_response.json.return_value = {'url': 'https://example.com/presigned'}
+    parquet_response = MagicMock(content=b'irrelevant')
+
+    with patch('brightwind.load.load.LoadBrightHub._brighthub_request', return_value=api_response), \
+            patch('brightwind.load.load.requests.get', return_value=parquet_response), \
+            patch('brightwind.load.load.pd.read_parquet', side_effect=ImportError("no engine")):
+        with pytest.raises(ImportError, match=r"brightwind\[parquet\].*brightwind\[parquet-fastparquet\]"):
+            bw.LoadBrightHub.get_data(measurement_station_uuid='uuid-1', file_extension='.parquet')


### PR DESCRIPTION
## Summary

Adds support for reading BrightHub timeseries data as Parquet files via a new `file_extension` argument on `LoadBrightHub.get_data` (one of `'.csv'` or `'.parquet'`). CSV remains the default in this release for backwards compatibility; Parquet is expected to become the default in the next major release.

Resolves #601.

## Changes

- **`LoadBrightHub.get_data`** ([brightwind/load/load.py](brightwind/load/load.py))
  - New `file_extension` keyword argument; forwarded to the BrightHub API by `__get_timeseries_data`.
  - `.parquet` responses are read from `BytesIO(response.content)` via `pd.read_parquet(..., engine='auto')` — pandas selects the installed engine, preferring `pyarrow` and falling back to `fastparquet`. Snappy decompression is handled transparently by either engine.
  - `.csv` path is unchanged.
  - Unsupported `file_extension` values raise `ValueError` before any network call.
  - If `.parquet` is requested without a parquet engine installed, `pd.read_parquet`'s `ImportError` is re-raised with a clear install hint naming both extras.
- **Deprecation warning**
  - Calls that omit `file_extension` emit a `DeprecationWarning` flagging the upcoming default flip to `.parquet`. Explicit `.csv` or `.parquet` calls are silent.
  - Implemented with a module-level `_FILE_EXTENSION_NOT_SET` sentinel so we can distinguish "user didn't pass" from "user passed `.csv`".
- **Packaging** ([setup.py](setup.py))
  - Adds `extras_require`:
    - `pip install brightwind[parquet]` → `pyarrow>=5.0.0` (pandas' preferred engine)
    - `pip install brightwind[parquet-fastparquet]` → `fastparquet>=0.8.0` (lighter alternative)
  - `install_requires` unchanged — default installs stay lean while CSV remains the default format.
- **Tests** ([tests/test_load.py](tests/test_load.py))
  - Five new mocked unit tests covering: implicit-default deprecation warning, explicit `.csv` silence, parquet round-trip with `Timestamp` preserved as datetime index, invalid-extension `ValueError`, and the `ImportError` re-raise with install hint.
  - Live `test_load_brighthub` extended to call `get_data` with `.csv` and `.parquet` against the BrightHub API and assert equivalent shape.
- **CHANGELOG** ([CHANGELOG.md](CHANGELOG.md)) — `[Unreleased]` section with `New Features and Enhancements` and `Deprecated` entries. `#TBC` issue link placeholders to be replaced once the issues are raised.

## Backwards compatibility

- Default `get_data()` behaviour is unchanged: still returns CSV-decoded data with `Timestamp` as the index. Existing call sites pass tests unmodified except for emitting a `DeprecationWarning`.
- `setup.py`'s `install_requires` is unchanged. Existing installs keep working without `pyarrow`/`fastparquet`. Users only need to install a parquet engine if they opt in to `file_extension='.parquet'`.

## Notes for reviewers

- Engine choice (`pyarrow` vs `fastparquet`) is deliberately left to the user, mirroring pandas' own `engine='auto'` resolution. We do not pin `engine=` in the `read_parquet` call.
- The default flip to `.parquet` is scoped for the **next major** release; this PR is a minor-version, backwards-compatible enhancement.
- A separate issue (to be raised) tracks whether `LoadBrightHub.get_data` should also expose the BrightHub API's filtering, cleaning and adjustment query parameters.

## Test plan

- [ ] `pytest tests/test_load.py -k "get_data"` passes locally with `pyarrow` installed.
- [ ] `pytest tests/test_load.py::test_load_brighthub_get_data_parquet` skips cleanly in an env without `pyarrow`/`fastparquet`.
- [ ] Existing `test_load_brighthub` still passes against the live BrightHub API for both `.csv` and `.parquet`.
- [ ] `python -c "import brightwind"` does not warn (deprecation is per-call, not on import).
- [ ] `pip install -e .` succeeds without parquet engines; `pip install -e .[parquet]` installs `pyarrow`; `pip install -e .[parquet-fastparquet]` installs `fastparquet`.
