### PR TITLE
iss609 support nested conditions and time_range_conditions in apply_c…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Additional labels for pre-release and build metadata are available as extensions
 XX-Xxx-2026
 
 ### New Features and Enhancements
-1. 
+1. Updated `apply_cleaning_rules()` to support nested boolean conditions (`and`/`or`/`not`) inside the `conditions` block and a new optional `time_range_conditions` block on cleaning rules, in line with the updated BrightHub `/measurement-locations/{uuid}/cleaning-rules` API response. Existing flat-condition cleaning rule files continue to work unchanged. The new `measurement_point_uuid` and `statistic_type_id` fields on `conditions` and `clean_out` items are accepted but currently ignored — column resolution still relies on `assembled_column_name`. The `cleaning_rule.schema.json` was extended with a `time_condition` definition.
 
 ### Bug Fixes
 1. 

--- a/brightwind/load/cleaning_rule.schema.json
+++ b/brightwind/load/cleaning_rule.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$version": "1.0.0",
+  "$version": "1.1.0",
   "definitions": {
     "condition": {
       "type": "object",
@@ -47,6 +47,44 @@
         { "required": ["or"], "maxProperties": 1 },
         { "required": ["not"], "maxProperties": 1 }
       ]
+    },
+    "time_condition": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "format": "date-time",
+          "description": "An ISO 8601 timestamp compared against the timeseries datetime index."
+        },
+        "comparison_operator_id": {
+          "type": "integer",
+          "oneOf": [
+            { "const": 1, "description": "is less than" },
+            { "const": 2, "description": "is less than or equal" },
+            { "const": 3, "description": "is greater than" },
+            { "const": 4, "description": "is greater than or equal" },
+            { "const": 5, "description": "equals" },
+            { "const": 6, "description": "not equals" }
+          ]
+        },
+        "and": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/time_condition" },
+          "minItems": 2
+        },
+        "or": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/time_condition" },
+          "minItems": 2
+        },
+        "not": { "$ref": "#/definitions/time_condition" }
+      },
+      "oneOf": [
+        { "required": ["value", "comparison_operator_id"] },
+        { "required": ["and"], "maxProperties": 1 },
+        { "required": ["or"], "maxProperties": 1 },
+        { "required": ["not"], "maxProperties": 1 }
+      ]
     }
   },
   "type": "object",
@@ -55,6 +93,7 @@
       "type": "object",
       "properties": {
         "conditions": { "$ref": "#/definitions/condition" },
+        "time_range_conditions": { "$ref": "#/definitions/time_condition" },
         "clean_out": {
           "type": "array",
           "items": {

--- a/brightwind/load/load.py
+++ b/brightwind/load/load.py
@@ -18,6 +18,7 @@ import time
 import concurrent
 import math
 import operator
+import functools
 
 
 __all__ = ['load_csv',
@@ -2467,53 +2468,60 @@ def apply_cleaning(data, cleaning_file_or_df, inplace=False, sensor_col_name='Se
     return data
 
 
-def _apply_cleaning_rule(df, condition_col, target_cols, comparator_value, comparison_operator_id, replacement_value, 
-                         date_from, date_to):
-    """Apply cleaning rule based on a single column to replace values on a list of columns
+def _build_date_range_mask(df, date_from, date_to):
+    """Build a boolean Series selecting rows of df.index within [date_from, date_to).
 
-    :param df:                      Data to be cleaned.       
-    :type df:                       pandas.DataFrame
-    :param condition_col:           Column that the cleaning rule is based on
-    :type condition_col:            str
-    :param target_cols:             Column to apply the cleaning rule to clean the data of
-    :type target_cols:              List[str]
-    :param comparator_value:        Threshold value to use in the cleaning rule, defined by 
-                                    the cleaning_rule_json format.
-    :type comparator_value:         float
-    :param comparison_operator_id:  Operator code (1-6) defined by the cleaning_rule_json format, to be used with
-                                    variable operator_dict to define the operator used on the condition column.
-                                    Code number corresponds to the following operators:
-                                        1: is less than (<),
-                                        2: is less than or equal (≤),
-                                        3: is greater than (>),
-                                        4: is greater than or equal (≥),
-                                        5: equals (=),
-                                        6: not equals (≠)
-    :type comparison_operator_id:   int
-    :param replacement_value:       Value or string to replace the data in the target_cols with
-    :type replacement_value:        str | np.nan
-    :param dates_from:              List of datetimes that the cleaning rule should be applied from for each column. 
-    :type dates_from:               str
-    :param dates_to:                List of datetimes that the cleaning rule should be applied until for each column. If
-                                    None is present the data is cleaned until the end of the file.
-    :type dates_to:                 str| None
-    :return:                        Cleaned data
-    :rtype:                         pandas.DataFrame
+    `date_from` is inclusive, `date_to` is exclusive (matches the schema documentation).
+    Either bound may be None — a None bound is treated as unbounded on that side.
     """
+    if date_from is None and date_to is None:
+        return pd.Series(True, index=df.index)
+    if date_to is None:
+        return pd.Series(df.index >= pd.Timestamp(date_from), index=df.index)
+    if date_from is None:
+        return pd.Series(df.index < pd.Timestamp(date_to), index=df.index)
+    return pd.Series((df.index >= pd.Timestamp(date_from)) & (df.index < pd.Timestamp(date_to)), index=df.index)
 
-    result_df = df
-    op = OPERATOR_DICT[comparison_operator_id]
-    mask = op(df[condition_col], comparator_value)
-    if date_to:
-        date_filter = (df.index >= date_from) & (df.index < date_to)
-    else:
-        date_filter = (df.index >= date_from)
 
-    for col in target_cols:
-        mask_date_range = mask & date_filter
-        result_df.loc[mask_date_range, col] = replacement_value
-    
-    return result_df
+def _evaluate_condition(df, condition):
+    """Recursively evaluate a column-based condition node and return a boolean Series aligned to df.index.
+
+    A node is either a single comparison with ``assembled_column_name`` / ``comparison_operator_id`` /
+    ``comparator_value``, or a boolean combinator with one of ``and`` / ``or`` / ``not`` wrapping
+    further nodes. Schema validation is assumed to have already enforced exactly one shape per node.
+    """
+    if 'and' in condition:
+        return functools.reduce(operator.and_,
+                                (_evaluate_condition(df, child) for child in condition['and']))
+    if 'or' in condition:
+        return functools.reduce(operator.or_,
+                                (_evaluate_condition(df, child) for child in condition['or']))
+    if 'not' in condition:
+        return ~_evaluate_condition(df, condition['not'])
+
+    op = OPERATOR_DICT[condition['comparison_operator_id']]
+    return op(df[condition['assembled_column_name']], condition['comparator_value'])
+
+
+def _evaluate_time_range_condition(df, condition):
+    """Recursively evaluate a time-range condition node and return a boolean Series aligned to df.index.
+
+    Mirrors :func:`_evaluate_condition` but each single comparison compares ``df.index`` against
+    an ISO timestamp ``value`` rather than comparing a column against a numeric ``comparator_value``.
+    """
+    if 'and' in condition:
+        return functools.reduce(operator.and_,
+                                (_evaluate_time_range_condition(df, child) for child in condition['and']))
+    if 'or' in condition:
+        return functools.reduce(operator.or_,
+                                (_evaluate_time_range_condition(df, child) for child in condition['or']))
+    if 'not' in condition:
+        return ~_evaluate_time_range_condition(df, condition['not'])
+
+    op = OPERATOR_DICT[condition['comparison_operator_id']]
+    result = op(df.index.to_series(), pd.Timestamp(condition['value']))
+    result.name = None
+    return result
 
 
 def apply_cleaning_rules(data, cleaning_rules_file_or_list, inplace=False, replacement_text='NaN'):
@@ -2571,6 +2579,39 @@ def apply_cleaning_rules(data, cleaning_rules_file_or_list, inplace=False, repla
             schema = json.load(file)
         schema
 
+    **Nested conditions**
+
+    The ``conditions`` block may be a single flat comparison or a recursive tree built with
+    ``and`` / ``or`` / ``not``. All forms are evaluated against the supplied DataFrame and the
+    resulting boolean mask is applied to the columns listed in ``clean_out``.
+    ::
+        "conditions": {"and": [
+            {"assembled_column_name": "Spd80mN", "comparison_operator_id": 1, "comparator_value": 10},
+            {"assembled_column_name": "T2m",     "comparison_operator_id": 3, "comparator_value": 5}
+        ]}
+
+    **Time-range conditions**
+
+    An optional ``time_range_conditions`` block (same nested ``and`` / ``or`` / ``not`` structure,
+    with ISO-timestamp ``value`` leaves) restricts cleaning to specific time windows. It is ANDed
+    with ``conditions`` and any ``date_from`` / ``date_to``.
+    ::
+        "time_range_conditions": {"and": [
+            {"value": "2016-02-01T00:00:00", "comparison_operator_id": 4},
+            {"value": "2017-09-01T00:00:00", "comparison_operator_id": 1}
+        ]}
+
+    **Stat-type expansion of ``clean_out``**
+
+    A ``clean_out`` item naming the avg column will also clean all associated stat-type columns at
+    the same measurement point (``_sd``, ``_max``, ``_min``, ``_count``, ``_availability``,
+    ``_quality``, ``_sum``, ``_median``, ``_mode``, ``_range``, ``_gust``, ``_ti``, ``_ti30sec``,
+    ``_text``, ``_val``) via substring matching on column names.
+
+    The new ``measurement_point_uuid`` and ``statistic_type_id`` fields on ``conditions`` and
+    ``clean_out`` items (added in the BrightHub API) are accepted but currently ignored — only
+    ``assembled_column_name`` is used for column resolution.
+
     """
 
     if inplace is False:
@@ -2597,20 +2638,23 @@ def apply_cleaning_rules(data, cleaning_rules_file_or_list, inplace=False, repla
 
     if replacement_text == 'NaN':
         replacement_text = np.nan
-    
+
     for cleaning_rule in cleaning_json:
-        columns_to_clean = [column_name['assembled_column_name'] for column_name in cleaning_rule['rule']['clean_out']]
-        date_from = cleaning_rule['rule'].get('date_from', data.index[0])
-        date_to = cleaning_rule['rule'].get('date_to', None)
-        columns_to_clean = [column_name for column_to_clean in columns_to_clean for column_name in data.columns 
+        rule = cleaning_rule['rule']
+
+        columns_to_clean = [c['assembled_column_name'] for c in rule['clean_out']]
+        columns_to_clean = [column_name for column_to_clean in columns_to_clean
+                            for column_name in data.columns
                             if column_to_clean in column_name]
 
-        condition_column_name = cleaning_rule['rule']['conditions']['assembled_column_name']
-        comparator_value = cleaning_rule['rule']['conditions']['comparator_value']
-        comparison_operator_id = cleaning_rule['rule']['conditions']['comparison_operator_id']
+        mask = _evaluate_condition(data, rule['conditions'])
+        mask &= _build_date_range_mask(data, rule.get('date_from'), rule.get('date_to'))
+        if 'time_range_conditions' in rule:
+            mask &= _evaluate_time_range_condition(data, rule['time_range_conditions'])
 
-        data = _apply_cleaning_rule(data, condition_column_name, columns_to_clean, comparator_value,
-                                    comparison_operator_id, replacement_text, date_from, date_to)
+        for col in columns_to_clean:
+            data.loc[mask, col] = replacement_text
+
     if inplace is False:
         return data
 

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -112,6 +112,185 @@ def test_apply_cleaning_rules():
     assert (data[data_original["T2m"] > 5][date_from:date_to]["Spd80mS"] == "-").all()
 
 
+def _synthetic_cleaning_df():
+    """Deterministic synthetic DataFrame for nested-condition / time-range tests."""
+    index = pd.date_range('2016-01-01', '2016-03-31 23:50', freq='10min')
+    n = len(index)
+    return pd.DataFrame(
+        {
+            'Spd': np.linspace(0, 20, n),
+            'Dir': np.linspace(0, 359, n),
+            'T2m': np.linspace(-10, 30, n),
+        },
+        index=index,
+    )
+
+
+def test_apply_cleaning_rules_nested_and_time_range():
+    df = _synthetic_cleaning_df()
+
+    # 1. Flat condition regression — equivalent to old single-condition behaviour.
+    rules = [{'rule': {
+        'clean_out': [{'assembled_column_name': 'Spd'}],
+        'conditions': {'assembled_column_name': 'Spd', 'comparison_operator_id': 1, 'comparator_value': 10},
+    }}]
+    cleaned = bw.apply_cleaning_rules(df, rules)
+    expected_mask = df['Spd'] < 10
+    assert cleaned.loc[expected_mask, 'Spd'].isna().all()
+    assert cleaned.loc[~expected_mask, 'Spd'].notna().all()
+
+    # 2. AND of two single comparisons — both must be true.
+    rules = [{'rule': {
+        'clean_out': [{'assembled_column_name': 'Spd'}],
+        'conditions': {'and': [
+            {'assembled_column_name': 'Spd', 'comparison_operator_id': 1, 'comparator_value': 10},
+            {'assembled_column_name': 'T2m', 'comparison_operator_id': 1, 'comparator_value': 5},
+        ]},
+    }}]
+    cleaned = bw.apply_cleaning_rules(df, rules)
+    expected_mask = (df['Spd'] < 10) & (df['T2m'] < 5)
+    assert cleaned.loc[expected_mask, 'Spd'].isna().all()
+    assert cleaned.loc[~expected_mask, 'Spd'].notna().all()
+
+    # 3. OR of two single comparisons — either may be true.
+    rules = [{'rule': {
+        'clean_out': [{'assembled_column_name': 'Spd'}],
+        'conditions': {'or': [
+            {'assembled_column_name': 'Spd', 'comparison_operator_id': 1, 'comparator_value': 5},
+            {'assembled_column_name': 'T2m', 'comparison_operator_id': 3, 'comparator_value': 20},
+        ]},
+    }}]
+    cleaned = bw.apply_cleaning_rules(df, rules)
+    expected_mask = (df['Spd'] < 5) | (df['T2m'] > 20)
+    assert cleaned.loc[expected_mask, 'Spd'].isna().all()
+    assert cleaned.loc[~expected_mask, 'Spd'].notna().all()
+
+    # 4. NOT — negation of a single comparison.
+    rules = [{'rule': {
+        'clean_out': [{'assembled_column_name': 'Spd'}],
+        'conditions': {'not': {'assembled_column_name': 'Spd', 'comparison_operator_id': 1, 'comparator_value': 10}},
+    }}]
+    cleaned = bw.apply_cleaning_rules(df, rules)
+    expected_mask = ~(df['Spd'] < 10)
+    assert cleaned.loc[expected_mask, 'Spd'].isna().all()
+    assert cleaned.loc[~expected_mask, 'Spd'].notna().all()
+
+    # 5. Nested AND containing OR.
+    rules = [{'rule': {
+        'clean_out': [{'assembled_column_name': 'Spd'}],
+        'conditions': {'and': [
+            {'assembled_column_name': 'Dir', 'comparison_operator_id': 4, 'comparator_value': 180},
+            {'or': [
+                {'assembled_column_name': 'Spd', 'comparison_operator_id': 1, 'comparator_value': 3},
+                {'assembled_column_name': 'Spd', 'comparison_operator_id': 3, 'comparator_value': 15},
+            ]},
+        ]},
+    }}]
+    cleaned = bw.apply_cleaning_rules(df, rules)
+    expected_mask = (df['Dir'] >= 180) & ((df['Spd'] < 3) | (df['Spd'] > 15))
+    assert cleaned.loc[expected_mask, 'Spd'].isna().all()
+    assert cleaned.loc[~expected_mask, 'Spd'].notna().all()
+
+    # 6. time_range_conditions alone (combined with an always-true conditions block).
+    rules = [{'rule': {
+        'clean_out': [{'assembled_column_name': 'Spd'}],
+        'conditions': {'assembled_column_name': 'Spd', 'comparison_operator_id': 4, 'comparator_value': -1},
+        'time_range_conditions': {'and': [
+            {'value': '2016-02-01T00:00:00', 'comparison_operator_id': 4},
+            {'value': '2016-03-01T00:00:00', 'comparison_operator_id': 1},
+        ]},
+    }}]
+    cleaned = bw.apply_cleaning_rules(df, rules)
+    expected_mask = (df.index >= pd.Timestamp('2016-02-01')) & (df.index < pd.Timestamp('2016-03-01'))
+    assert cleaned.loc[expected_mask, 'Spd'].isna().all()
+    assert cleaned.loc[~expected_mask, 'Spd'].notna().all()
+
+    # 7. time_range_conditions ANDed with a measurement condition.
+    rules = [{'rule': {
+        'clean_out': [{'assembled_column_name': 'Spd'}],
+        'conditions': {'assembled_column_name': 'Spd', 'comparison_operator_id': 1, 'comparator_value': 10},
+        'time_range_conditions': {'and': [
+            {'value': '2016-02-01T00:00:00', 'comparison_operator_id': 4},
+            {'value': '2016-03-01T00:00:00', 'comparison_operator_id': 1},
+        ]},
+    }}]
+    cleaned = bw.apply_cleaning_rules(df, rules)
+    in_window = (df.index >= pd.Timestamp('2016-02-01')) & (df.index < pd.Timestamp('2016-03-01'))
+    expected_mask = (df['Spd'] < 10) & in_window
+    assert cleaned.loc[expected_mask, 'Spd'].isna().all()
+    assert cleaned.loc[~expected_mask, 'Spd'].notna().all()
+
+    # 8. time_range_conditions combined with date_from/date_to — all three ANDed.
+    rules = [{'rule': {
+        'clean_out': [{'assembled_column_name': 'Spd'}],
+        'conditions': {'assembled_column_name': 'Spd', 'comparison_operator_id': 4, 'comparator_value': -1},
+        'date_from': '2016-01-15T00:00:00',
+        'date_to': '2016-03-15T00:00:00',
+        'time_range_conditions': {'and': [
+            {'value': '2016-02-01T00:00:00', 'comparison_operator_id': 4},
+            {'value': '2016-04-01T00:00:00', 'comparison_operator_id': 1},
+        ]},
+    }}]
+    cleaned = bw.apply_cleaning_rules(df, rules)
+    expected_mask = (
+        (df.index >= pd.Timestamp('2016-01-15')) & (df.index < pd.Timestamp('2016-03-15')) &
+        (df.index >= pd.Timestamp('2016-02-01')) & (df.index < pd.Timestamp('2016-04-01'))
+    )
+    assert cleaned.loc[expected_mask, 'Spd'].isna().all()
+    assert cleaned.loc[~expected_mask, 'Spd'].notna().all()
+
+    # 9. Validation error — single comparison missing comparator_value.
+    rules = [{'rule': {
+        'clean_out': [{'assembled_column_name': 'Spd'}],
+        'conditions': {'assembled_column_name': 'Spd', 'comparison_operator_id': 1},
+    }}]
+    with pytest.raises(ValueError) as except_info:
+        bw.apply_cleaning_rules(df, rules)
+    assert "validity of the supplied JSON" in str(except_info.value)
+
+    # 10. Stat-type expansion — clean_out on the avg column also cleans all stat variants present.
+    index = pd.date_range('2016-01-01', '2016-01-02 23:50', freq='10min')
+    n = len(index)
+    df_stats = pd.DataFrame(
+        {
+            'Spd_40m': np.linspace(0, 20, n),
+            'Spd_40m_sd': np.linspace(0, 2, n),
+            'Spd_40m_max': np.linspace(0, 25, n),
+            'Spd_40m_min': np.linspace(0, 15, n),
+            'OtherCol': np.linspace(0, 1, n),
+        },
+        index=index,
+    )
+    rules = [{'rule': {
+        'clean_out': [{'assembled_column_name': 'Spd_40m'}],
+        'conditions': {'assembled_column_name': 'Spd_40m', 'comparison_operator_id': 1, 'comparator_value': 10},
+    }}]
+    cleaned = bw.apply_cleaning_rules(df_stats, rules)
+    mask = df_stats['Spd_40m'] < 10
+    for col in ('Spd_40m', 'Spd_40m_sd', 'Spd_40m_max', 'Spd_40m_min'):
+        assert cleaned.loc[mask, col].isna().all()
+        assert cleaned.loc[~mask, col].notna().all()
+    assert cleaned['OtherCol'].notna().all()
+
+    # New fields measurement_point_uuid and statistic_type_id are accepted but ignored.
+    rules = [{'rule': {
+        'clean_out': [{
+            'assembled_column_name': 'Spd_40m',
+            'measurement_point_uuid': '00000000-0000-0000-0000-000000000000',
+            'statistic_type_id': 'avg',
+        }],
+        'conditions': {
+            'assembled_column_name': 'Spd_40m',
+            'comparison_operator_id': 1,
+            'comparator_value': 10,
+            'measurement_point_uuid': '00000000-0000-0000-0000-000000000000',
+            'statistic_type_id': 'avg',
+        },
+    }}]
+    cleaned = bw.apply_cleaning_rules(df_stats, rules)
+    assert cleaned.loc[mask, 'Spd_40m'].isna().all()
+
+
 def test_load_csv():
     data = bw.load_csv(os.path.join(DEMO_DATA_FOLDER, 'demo_data.csv'))
     data2 = bw.load_csv(os.path.join(DEMO_DATA_FOLDER, 'demo_data2.csv'), dayfirst=True)


### PR DESCRIPTION
## Summary

Updates `apply_cleaning_rules()` to consume the new BrightHub `/measurement-locations/{uuid}/cleaning-rules` API response shape: nested `and`/`or`/`not` boolean conditions and a new optional `time_range_conditions` block. Existing flat-condition rule files continue to work unchanged.

Resolves #609.

## Changes

- **`apply_cleaning_rules()` ([brightwind/load/load.py](brightwind/load/load.py))** — recursive evaluator for nested `conditions` and a new optional `time_range_conditions` block (ISO-timestamp leaves, evaluated against the DataFrame index, ANDed with `conditions` / `date_from` / `date_to`). New `measurement_point_uuid` and `statistic_type_id` fields are accepted but ignored — column resolution still uses `assembled_column_name`. The old private `_apply_cleaning_rule` helper is removed.
- **[brightwind/load/cleaning_rule.schema.json](brightwind/load/cleaning_rule.schema.json)** — new `time_condition` definition + `time_range_conditions` property; `$version` bumped to `1.1.0`.
- **[tests/test_load.py](tests/test_load.py)** — new `test_apply_cleaning_rules_nested_and_time_range` covering flat (regression), `and`, `or`, `not`, nested combinations, `time_range_conditions` alone and combined with `date_from`/`date_to`, validation error, and statistic-type column expansion of `clean_out`.
- **[CHANGELOG.md](CHANGELOG.md)** — entry under `## [2.X.X]`.

## Follow-ups (separate issues)

- Replace substring-match `clean_out` resolution with strict expansion to known stat-type suffixes (breaking — next major release).
- Add a `LoadBrightHub` normaliser that resolves `measurement_point_uuid` → `assembled_column_name` before rules reach the generic engine.

## Test plan
- [ ] `pytest tests/test_load.py::test_apply_cleaning_rules` — regression check passes unchanged.
- [ ] `pytest tests/test_load.py::test_apply_cleaning_rules_nested_and_time_range` — all subtests pass.
- [ ] `pytest tests/test_load.py` — no unrelated regressions.
- [ ] End-to-end: feed a representative BrightHub response (flat + nested `and` + `time_range_conditions`) into `apply_cleaning_rules` against a real DataFrame and verify the mask is correct.
