### PR TITLE
[iss623] Move pytest to development dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ scikit-learn    >= 0.19.1
 matplotlib      >= 3.0.3
 requests        >= 2.20.0
 scipy           >= 0.19.1
-pytest          >= 4.1.0
 six             >= 1.12.0
 python-dateutil >= 2.8.0
 ipywidgets      >= 7.4.2

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ setup(
         'matplotlib>=3.0.3',
         'requests>=2.20.0',
         'scipy>=0.19.1',
-        'pytest>= 4.1.0',
         'six>= 1.12.0',
         'python-dateutil>=2.8.0',
         'ipywidgets>=7.4.2',
@@ -66,6 +65,7 @@ setup(
         # pandas picks the installed engine at read time (prefers pyarrow, falls back to fastparquet).
         'parquet': ['pyarrow>=5.0.0'],
         'parquet-fastparquet': ['fastparquet>=0.8.0'],
+        'dev': ['pytest>=4.1.0'],
     },
     classifiers=[
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
# [iss623] Move pytest to development dependencies

## Summary

`pytest` was declared as a runtime dependency in both package metadata and the requirements file, even though it is only used by the test suite. This removes it from normal installations and makes it available through the `dev` extra for contributors.

Fixes #623

## Changes

- Remove `pytest` from `install_requires` and `requirements.txt`.
- Add `pytest>=4.1.0` to the `dev` optional dependency extra.

## Testing

Ran in the required sandbox:

```sh
python -m venv /tmp/brightwind-runtime && /tmp/brightwind-runtime/bin/python -m pip install --upgrade pip && /tmp/brightwind-runtime/bin/python -m pip install . && /tmp/brightwind-runtime/bin/python -c "import importlib.util; assert importlib.util.find_spec('pytest') is None" && /tmp/brightwind-runtime/bin/python -m pip install '.[dev]' && /tmp/brightwind-runtime/bin/python -c "import pytest; print(pytest.__version__)"
```

The normal package installation completed without `pytest`; installing `.[dev]` then installed and imported `pytest` successfully.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
